### PR TITLE
Fix/tao 4972/set broker through setter

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label' => 'Task Queue',
     'description' => 'TAO specific Task Queue with custom GUI',
     'license' => 'GPL-2.0',
-    'version' => '0.1.0',
+    'version' => '0.1.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=4.4.3',

--- a/model/Queue.php
+++ b/model/Queue.php
@@ -85,6 +85,20 @@ class Queue extends ConfigurableService implements QueueInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function setBroker(QueueBrokerInterface $broker)
+    {
+        // removes current broker instance
+        $this->broker = null;
+
+        // add broker through option
+        $this->setOption(self::OPTION_QUEUE_BROKER, $broker);
+
+        return $this;
+    }
+
+    /**
      * Returns the queue broker service.
      *
      * @return QueueBrokerInterface

--- a/model/QueueInterface.php
+++ b/model/QueueInterface.php
@@ -20,6 +20,7 @@
 
 namespace oat\taoTaskQueue\model;
 
+use oat\taoTaskQueue\model\QueueBroker\QueueBrokerInterface;
 use oat\taoTaskQueue\model\Task\CallbackTask;
 use oat\taoTaskQueue\model\Task\TaskInterface;
 use Psr\Log\LoggerAwareInterface;
@@ -52,6 +53,14 @@ interface QueueInterface extends \Countable, LoggerAwareInterface
      * @return string
      */
     public function getName();
+
+    /**
+     * Set new broker.
+     *
+     * @param QueueBrokerInterface $broker
+     * @return QueueInterface
+     */
+    public function setBroker(QueueBrokerInterface $broker);
 
     /**
      * Create a task to be managed by the queue from any callable

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -32,5 +32,6 @@ class Updater extends common_ext_ExtensionUpdater
 {
     public function update($initialVersion)
     {
+        $this->skip('0.1.0', '0.1.1');
     }
 }


### PR DESCRIPTION
Setting the broker through setter to be able to remove the current broker instance so the new one will be recognised straightaway.