### PR TITLE
Feature/tao 5173/add ability to link a resource

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label' => 'Task Queue',
     'description' => 'TAO specific Task Queue with custom GUI',
     'license' => 'GPL-2.0',
-    'version' => '0.3.0',
+    'version' => '0.4.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=4.4.3',

--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label' => 'Task Queue',
     'description' => 'TAO specific Task Queue with custom GUI',
     'license' => 'GPL-2.0',
-    'version' => '0.2.4',
+    'version' => '0.3.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=4.4.3',

--- a/model/QueueDispatcher.php
+++ b/model/QueueDispatcher.php
@@ -475,7 +475,7 @@ class QueueDispatcher extends ConfigurableService implements QueueDispatcherInte
      * @param \core_kernel_classes_Resource|null $resource - placeholder resource to be linked with task.
      * @return \core_kernel_classes_Resource
      */
-    public function linkTask(TaskInterface $task, \core_kernel_classes_Resource $resource = null)
+    public function linkTaskToResource(TaskInterface $task, \core_kernel_classes_Resource $resource = null)
     {
         $taskResource = $this->getResource($task->getId());
 

--- a/model/QueueDispatcherInterface.php
+++ b/model/QueueDispatcherInterface.php
@@ -163,4 +163,34 @@ interface QueueDispatcherInterface extends \Countable, LoggerAwareInterface
      * @return bool
      */
     public function isSync();
-}
+
+    /**
+     * Get resource from rdf storage which represents task in the task queue by linked resource
+     * Returns null if there is no task linked to given resource
+     *
+     * It will be deprecated once we have the general GUI for displaying different info of a task for the user.
+     *
+     * @param \core_kernel_classes_Resource $resource
+     * @return null|\core_kernel_classes_Resource
+     */
+    public function getTaskResource(\core_kernel_classes_Resource $resource);
+
+    /**
+     * Get report by a linked resource.
+     *
+     * It will be deprecated once we have the general GUI for displaying different info of a task for the user.
+     *
+     * @param \core_kernel_classes_Resource $resource
+     * @return \common_report_Report
+     */
+    public function getReportByLinkedResource(\core_kernel_classes_Resource $resource);
+
+    /**
+     * Create task resource in the rdf storage and link placeholder resource to it.
+     *
+     * It will be deprecated once we have the general GUI for displaying different info of a task for the user.
+     *
+     * @param TaskInterface $task
+     * @param \core_kernel_classes_Resource|null $resource Placeholder resource linked to the task
+     */
+    public function linkTask(TaskInterface $task, \core_kernel_classes_Resource $resource = null);}

--- a/model/QueueDispatcherInterface.php
+++ b/model/QueueDispatcherInterface.php
@@ -193,4 +193,4 @@ interface QueueDispatcherInterface extends \Countable, LoggerAwareInterface
      * @param TaskInterface $task
      * @param \core_kernel_classes_Resource|null $resource Placeholder resource linked to the task
      */
-    public function linkTask(TaskInterface $task, \core_kernel_classes_Resource $resource = null);}
+    public function linkTaskToResource(TaskInterface $task, \core_kernel_classes_Resource $resource = null);}

--- a/model/TaskLogActionTrait.php
+++ b/model/TaskLogActionTrait.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\taoTaskQueue\model;
+
+use common_report_Report as Report;
+use oat\oatbox\service\ServiceManager;
+use oat\taoTaskQueue\model\Entity\TaskLogEntity;
+
+/**
+ * Helper trait for legacy REST actions/controllers to operate with task log data for a given task.
+ *
+ * @author Gyula Szucs <gyula@taotesting.com>
+ */
+trait TaskLogActionTrait
+{
+    /**
+     * @return ServiceManager
+     */
+    abstract protected function getServiceManager();
+
+    /**
+     * @param string $taskId
+     * @param string $userId
+     * @return TaskLogEntity
+     */
+    protected function getTaskLogEntity($taskId, $userId = null)
+    {
+        /** @var TaskLogInterface $taskLog */
+        $taskLog = $this->getServiceManager()->get(TaskLogInterface::SERVICE_ID);
+
+        if (is_null($userId)) {
+            $userId = \common_session_SessionManager::getSession()->getUserUri();
+        }
+
+        return $taskLog->getByIdAndUser((string) $taskId, (string) $userId);
+    }
+
+    /**
+     * @param string $taskId
+     * @param string|null $forcedTaskType
+     * @param string|null $userId
+     * @return array
+     * @throws \common_exception_BadRequest
+     */
+    protected function getTaskLogReturnData($taskId, $forcedTaskType = null, $userId = null)
+    {
+        $taskLogEntity = $this->getTaskLogEntity($taskId, $userId);
+
+        if (!is_null($forcedTaskType) && $taskLogEntity->getTaskName() !== $forcedTaskType) {
+            throw new \common_exception_BadRequest("Wrong task type");
+        }
+
+        $result['id']     = $this->getTaskId($taskLogEntity);
+        $result['status'] = $this->getTaskStatus($taskLogEntity);
+        $result['report'] = $taskLogEntity->getReport() ? $this->getTaskReport($taskLogEntity) : [];
+
+        return array_merge($result, (array) $this->addExtraReturnData($taskLogEntity));
+    }
+
+    /**
+     * Return task identifier
+     *
+     * @param TaskLogEntity $taskLogEntity
+     * @return string
+     */
+    protected function getTaskId(TaskLogEntity $taskLogEntity)
+    {
+        return $taskLogEntity->getId();
+    }
+
+    /**
+     * @param TaskLogEntity $taskLogEntity
+     * @return string
+     */
+    protected function getTaskStatus(TaskLogEntity $taskLogEntity)
+    {
+        return $taskLogEntity->getStatus()->getLabel();
+    }
+
+    /**
+     * As default, it returns the reports as an associative array.
+     *
+     * @param TaskLogEntity $taskLogEntity
+     * @return array
+     */
+    protected function getTaskReport(TaskLogEntity $taskLogEntity)
+    {
+        return $this->getReportAsAssociativeArray($taskLogEntity->getReport());
+    }
+
+    /**
+     * @return array
+     */
+    protected function addExtraReturnData(TaskLogEntity $taskLogEntity)
+    {
+        return [];
+    }
+
+    /**
+     * @param Report $report
+     * @return Report[]
+     */
+    protected function getPlainReport(Report $report)
+    {
+        $reports[] = $report;
+
+        if ($report->hasChildren()) {
+            foreach ($report as $r) {
+                $reports = array_merge($reports, $this->getPlainReport($r));
+            }
+        }
+
+        return $reports;
+    }
+
+    /**
+     * @param Report $report
+     * @return array
+     */
+    protected function getReportAsAssociativeArray(Report $report)
+    {
+        $reports = [];
+        $plainReports = $this->getPlainReport($report);
+
+        foreach ($plainReports as $r) {
+            $reports[] = [
+                'type'    => $r->getType(),
+                'message' => $r->getMessage(),
+            ];
+        }
+
+        return $reports;
+    }
+}

--- a/model/TaskLogActionTrait.php
+++ b/model/TaskLogActionTrait.php
@@ -47,10 +47,20 @@ trait TaskLogActionTrait
         $taskLog = $this->getServiceManager()->get(TaskLogInterface::SERVICE_ID);
 
         if (is_null($userId)) {
-            $userId = \common_session_SessionManager::getSession()->getUserUri();
+            $userId = $this->getUserId();
         }
 
         return $taskLog->getByIdAndUser((string) $taskId, (string) $userId);
+    }
+
+    /**
+     * Get default user id.
+     *
+     * @return string
+     */
+    protected function getUserId()
+    {
+        return \common_session_SessionManager::getSession()->getUserUri();
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -56,6 +56,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('0.2.0');
         }
 
-        $this->skip('0.2.0', '0.3.0');
+        $this->skip('0.2.0', '0.4.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -56,6 +56,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('0.2.0');
         }
 
-        $this->skip('0.2.0', '0.2.4');
+        $this->skip('0.2.0', '0.3.0');
     }
 }

--- a/test/model/Entity/TaskLogEntityTest.php
+++ b/test/model/Entity/TaskLogEntityTest.php
@@ -39,7 +39,7 @@ class TaskLogEntityTest extends \PHPUnit_Framework_TestCase
             'updated_at' => '2017-02-01 14:00:01',
             'report' => [
                 'type' => 'info',
-                'message' => 'Running task http://www.act.dev/ontologies/tao.rdf#i1508337970199318643',
+                'message' => 'Running task http://www.taoinstance.dev/ontologies/tao.rdf#i1508337970199318643',
                 'data' => NULL,
                 'children' => []
             ],
@@ -65,7 +65,7 @@ class TaskLogEntityTest extends \PHPUnit_Framework_TestCase
             'updatedAt' => '2017-02-01T14:00:01+00:00',
             'report' => [
                 'type' => 'info',
-                'message' => 'Running task http://www.act.dev/ontologies/tao.rdf#i1508337970199318643',
+                'message' => 'Running task http://www.taoinstance.dev/ontologies/tao.rdf#i1508337970199318643',
                 'data' => NULL,
                 'children' => []
             ]

--- a/test/model/QueueDispatcherTest.php
+++ b/test/model/QueueDispatcherTest.php
@@ -9,10 +9,6 @@ use oat\taoTaskQueue\model\Task\AbstractTask;
 use oat\taoTaskQueue\model\Task\CallbackTaskInterface;
 use oat\taoTaskQueue\test\model\Asset\CallableFixture;
 
-/**
- * @backupGlobals disabled
- * @backupStaticAttributes disabled
- */
 class QueueDispatcherTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()

--- a/test/model/QueueTest.php
+++ b/test/model/QueueTest.php
@@ -25,10 +25,6 @@ use oat\taoTaskQueue\model\QueueBroker\QueueBrokerInterface;
 use oat\taoTaskQueue\model\Queue;
 use oat\taoTaskQueue\model\TaskLogInterface;
 
-/**
- * @backupGlobals disabled
- * @backupStaticAttributes disabled
- */
 class QueueTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()

--- a/test/model/Task/AbstractTaskTest.php
+++ b/test/model/Task/AbstractTaskTest.php
@@ -23,10 +23,6 @@ namespace oat\taoTaskQueue\test\model\Task;
 use oat\taoTaskQueue\model\Task\AbstractTask;
 use oat\taoTaskQueue\model\Task\TaskInterface;
 
-/**
- * @backupGlobals disabled
- * @backupStaticAttributes disabled
- */
 class AbstractTaskTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/test/model/Task/CallbackTaskTest.php
+++ b/test/model/Task/CallbackTaskTest.php
@@ -25,10 +25,6 @@ use oat\taoTaskQueue\model\Task\CallbackTask;
 use oat\taoTaskQueue\model\Task\CallbackTaskInterface;
 use oat\taoTaskQueue\model\Task\TaskInterface;
 
-/**
- * @backupGlobals disabled
- * @backupStaticAttributes disabled
- */
 class CallbackTaskTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/test/model/TaskLogActionTraitTest.php
+++ b/test/model/TaskLogActionTraitTest.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\taoTaskQueue\test\model;
+
+use oat\oatbox\service\ServiceManager;
+use oat\taoTaskQueue\model\Entity\TaskLogEntity;
+use oat\taoTaskQueue\model\TaskLog;
+use oat\taoTaskQueue\model\TaskLogActionTrait;
+use oat\taoTaskQueue\model\ValueObjects\TaskLogCategorizedStatus;
+
+class TaskLogActionTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetTaskLogEntityWhenOnlyTaskIdIsProvidedThenGetTheDefaultUser()
+    {
+        $taskLogEntityMock = $this->getMockBuilder(TaskLogEntity::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $taskLogMock = $this->getMockBuilder(TaskLog::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getByIdAndUser'])
+            ->getMock();
+
+        $taskLogMock->expects($this->once())
+            ->method('getByIdAndUser')
+            ->willReturn($taskLogEntityMock);
+
+        $serviceManagerMock = $this->getMockBuilder(ServiceManager::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get'])
+            ->getMockForAbstractClass();
+
+        $serviceManagerMock->expects($this->once())
+            ->method('get')
+            ->willReturn($taskLogMock);
+
+        $traitMock = $this->getMockBuilder(TaskLogActionTrait::class)
+            ->setMethods(['getServiceManager', 'getUserId'])
+            ->getMockForTrait();
+
+        $traitMock->expects($this->once())
+            ->method('getServiceManager')
+            ->willReturn($serviceManagerMock);
+
+        $traitMock->expects($this->once())
+            ->method('getUserId');
+
+        $entityCaller = function () {
+            return $this->getTaskLogEntity('fakeTaskId');
+        };
+
+        $bound = $entityCaller->bindTo($traitMock, $traitMock);
+
+        $this->assertInstanceOf(TaskLogEntity::class, $bound());
+    }
+
+    public function testTaskIdGetter()
+    {
+        $fakeId = 'fakeTaskId#000111';
+
+        $taskLogEntityMock = $this->getTaskLogEntityMock();
+
+        $taskLogEntityMock->expects($this->once())
+            ->method('getId')
+            ->willReturn($fakeId);
+
+        $traitMock = $this->getMockBuilder(TaskLogActionTrait::class)
+            ->getMockForTrait();
+
+        $idCaller = function () use ($taskLogEntityMock) {
+            return $this->getTaskId($taskLogEntityMock);
+        };
+        $bound = $idCaller->bindTo($traitMock, $traitMock);
+        $this->assertEquals($fakeId, $bound());
+    }
+
+    public function testTaskStatusGetter()
+    {
+        $fakeLabel = 'fakeStatus Label';
+
+        $categorizedStatusMock = $this->getMockBuilder(TaskLogCategorizedStatus::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getLabel'])
+            ->getMock();
+
+        $categorizedStatusMock->expects($this->once())
+            ->method('getLabel')
+            ->willReturn($fakeLabel);
+
+        $taskLogEntityMock = $this->getTaskLogEntityMock();
+
+        $taskLogEntityMock->expects($this->once())
+            ->method('getStatus')
+            ->willReturn($categorizedStatusMock);
+
+        $traitMock = $this->getMockBuilder(TaskLogActionTrait::class)
+            ->getMockForTrait();
+
+        $statusCaller = function () use ($taskLogEntityMock) {
+            return $this->getTaskStatus($taskLogEntityMock);
+        };
+        $bound = $statusCaller->bindTo($traitMock, $traitMock);
+        $this->assertEquals($fakeLabel, $bound());
+    }
+
+    public function testTaskReportGetter()
+    {
+        $reportMock = $this->getMockBuilder(\common_report_Report::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $taskLogEntityMock = $this->getTaskLogEntityMock();
+
+        $taskLogEntityMock->expects($this->once())
+            ->method('getReport')
+            ->willReturn($reportMock);
+
+        $traitMock = $this->getMockBuilder(TaskLogActionTrait::class)
+            ->setMethods(['getReportAsAssociativeArray'])
+            ->getMockForTrait();
+
+        $expectedReport[] = [
+            'type'    => 'info',
+            'message' => 'Running task http://www.taoinstance.dev/ontologies/tao.rdf#i1508337970199318643',
+        ];
+
+        $traitMock->expects($this->once())
+            ->method('getReportAsAssociativeArray')
+            ->willReturn($expectedReport);
+
+        $reportCaller = function () use ($taskLogEntityMock) {
+            return $this->getTaskReport($taskLogEntityMock);
+        };
+        $bound = $reportCaller->bindTo($traitMock, $traitMock);
+        $this->assertEquals($expectedReport, $bound());
+    }
+
+    protected function getTaskLogEntityMock()
+    {
+        $taskLogEntityMock = $this->getMockBuilder(TaskLogEntity::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getId', 'getStatus', 'getReport', 'getTaskName'])
+            ->getMock();
+
+        return $taskLogEntityMock;
+    }
+
+    /**
+     * @expectedException \common_exception_BadRequest
+     */
+    public function testGetTaskLogReturnDataWhenTaskTypeIsProvidedButTheTaskIdBelongsToDifferentTypeOfTaskThenThrowException()
+    {
+        $taskLogEntityMock = $this->getTaskLogEntityMock();
+
+        $taskLogEntityMock->expects($this->once())
+            ->method('getTaskName')
+            ->willReturn('oat\taoDeliveryRdf\model\tasks\ImportAndCompile');
+
+        $traitMock = $this->getMockBuilder(TaskLogActionTrait::class)
+            ->setMethods(['getTaskLogEntity'])
+            ->getMockForTrait();
+
+        $traitMock->expects($this->once())
+            ->method('getTaskLogEntity')
+            ->willReturn($taskLogEntityMock);
+
+        $dataCaller = function () {
+            return $this->getTaskLogReturnData('fakeId', 'oat\taoDeliveryRdf\model\tasks\CompileDelivery');
+        };
+        $bound = $dataCaller->bindTo($traitMock, $traitMock);
+
+        $bound();
+    }
+
+    public function testGetTaskLogForProperResult()
+    {
+        $taskId = 'fakeTaskId#2536485';
+        $statusLabel = 'fakeStatus Label';
+        $reportArray = [
+            'type' => 'fakeType',
+            'message' => 'fakeMessage'
+        ];
+
+        $taskLogEntityMock = $this->getTaskLogEntityMock();
+
+        $taskLogEntityMock->expects($this->once())
+            ->method('getReport')
+            ->willReturn(true);
+
+        $traitMock = $this->getMockBuilder(TaskLogActionTrait::class)
+            ->setMethods(['getTaskLogEntity', 'getTaskId', 'getTaskStatus', 'getTaskReport'])
+            ->getMockForTrait();
+
+        $traitMock->expects($this->once())
+            ->method('getTaskLogEntity')
+            ->willReturn($taskLogEntityMock);
+
+        $traitMock->expects($this->once())
+            ->method('getTaskId')
+            ->willReturn($taskId);
+
+        $traitMock->expects($this->once())
+            ->method('getTaskStatus')
+            ->willReturn($statusLabel);
+
+        $traitMock->expects($this->once())
+            ->method('getTaskReport')
+            ->willReturn($reportArray);
+
+        $dataCaller = function () use ($taskId) {
+            return $this->getTaskLogReturnData($taskId);
+        };
+        $bound = $dataCaller->bindTo($traitMock, $traitMock);
+
+        $expectedData = [
+            'id' => $taskId,
+            'status' => $statusLabel,
+            'report' => $reportArray
+        ];
+
+        $this->assertEquals($expectedData, $bound());
+    }
+}

--- a/test/model/TaskLogBroker/RdsTaskLogBrokerTest.php
+++ b/test/model/TaskLogBroker/RdsTaskLogBrokerTest.php
@@ -23,10 +23,6 @@ namespace oat\taoTaskQueue\test\model\TaskLogBroker;
 use oat\oatbox\service\ServiceManager;
 use oat\taoTaskQueue\model\TaskLogBroker\RdsTaskLogBroker;
 
-/**
- * @backupGlobals disabled
- * @backupStaticAttributes disabled
- */
 class RdsTaskLogBrokerTest extends \PHPUnit_Framework_TestCase
 {
     /**

--- a/test/model/TaskLogTest.php
+++ b/test/model/TaskLogTest.php
@@ -27,10 +27,6 @@ use oat\taoTaskQueue\model\TaskLog;
 use oat\taoTaskQueue\model\TaskLogBroker\TaskLogBrokerInterface;
 use oat\taoTaskQueue\model\TaskLogBroker\TaskLogCollection;
 
-/**
- * @backupGlobals disabled
- * @backupStaticAttributes disabled
- */
 class TaskLogTest extends \PHPUnit_Framework_TestCase
 {
     /**


### PR DESCRIPTION
For the time being, until we have the general GUI for displaying info of a task, we have to support these legacy methods:
- getTaskResource
- getReportByLinkedResource
- linkTaskToResource

A new trait called TaskLogActionTrait has been added to support legacy REST actions/controllers.