### PR TITLE
Feature/tao 5252/add script to import from old task queue

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label' => 'Task Queue',
     'description' => 'TAO specific Task Queue with custom GUI',
     'license' => 'GPL-2.0',
-    'version' => '0.4.0',
+    'version' => '0.4.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=4.4.3',

--- a/model/QueueDispatcher.php
+++ b/model/QueueDispatcher.php
@@ -44,6 +44,9 @@ class QueueDispatcher extends ConfigurableService implements QueueDispatcherInte
      */
     private $taskLog;
 
+    /** @var  string */
+    private $owner;
+
     /**
      * QueueDispatcher constructor.
      *
@@ -260,7 +263,7 @@ class QueueDispatcher extends ConfigurableService implements QueueDispatcherInte
     public function createTask(callable $callable, array $parameters = [], $label = null)
     {
         $id = \common_Utils::getNewUri();
-        $owner = \common_session_SessionManager::getSession()->getUser()->getIdentifier();
+        $owner = $this->getOwner();
 
         $callbackTask = new CallbackTask($id, $owner);
         $callbackTask->setCallable($callable)
@@ -271,6 +274,27 @@ class QueueDispatcher extends ConfigurableService implements QueueDispatcherInte
         }
 
         return $callbackTask;
+    }
+
+    /**
+     * @param string $owner
+     */
+    public function setOwner($owner)
+    {
+        $this->owner = $owner;
+    }
+
+    /**
+     * @return string
+     * @throws \common_exception_Error
+     */
+    public function getOwner()
+    {
+        if (is_null($this->owner)){
+            return \common_session_SessionManager::getSession()->getUser()->getIdentifier();
+        }
+
+        return $this->owner;
     }
 
     /**

--- a/scripts/tools/MigrateQueueMessages.php
+++ b/scripts/tools/MigrateQueueMessages.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\taoTaskQueue\scripts\tools;
+
+use oat\oatbox\action\Action;
+use oat\oatbox\task\Task;
+use oat\taoTaskQueue\model\QueueDispatcher;
+use oat\taoTaskQueue\model\QueueDispatcherInterface;
+use oat\Taskqueue\JsonTask;
+use oat\Taskqueue\Persistence\RdsQueue;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+
+/**
+ * ```
+ * $ sudo -u www-data php index.php 'oat\taoTaskQueue\scripts\tools\MigrateQueueMessages'
+ * ```
+ */
+
+class MigrateQueueMessages implements Action, ServiceLocatorAwareInterface
+{
+    use ServiceLocatorAwareTrait;
+
+    public function __invoke($params)
+    {
+        try {
+            $count = 0;
+
+            /** @var RdsQueue $oldRdsQueue */
+            $oldRdsQueue = $this->getServiceLocator()->get(RdsQueue::SERVICE_ID);
+            /** @var QueueDispatcher $queueService */
+            $queueService = $this->getServiceLocator()->get(QueueDispatcherInterface::SERVICE_ID);
+
+            /** @var JsonTask $queueItem */
+            foreach ($oldRdsQueue as $queueItem)
+            {
+                $label = $queueItem->getLabel();
+                $invokeString = $queueItem->getInvocable();
+                $parameters = $queueItem->getParameters();
+
+                $queueService->setOwner($queueItem->getOwner());
+                $queueService->createTask(new $invokeString, $parameters, $label);
+
+                $oldRdsQueue->updateTaskStatus($queueItem->getId(), Task::STATUS_ARCHIVED);
+                $count++;
+            }
+
+            return \common_report_Report::createSuccess('Imported with success: '. $count);
+
+        } catch (\Exception $exception) {
+
+            $message = $exception->getMessage();
+            return \common_report_Report::createFailure($message);
+        }
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -56,6 +56,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('0.2.0');
         }
 
-        $this->skip('0.2.0', '0.4.0');
+        $this->skip('0.2.0', '0.4.1');
     }
 }


### PR DESCRIPTION
I did create this script if it will help you to migrate task queue from previous queue that we have into the new one.

- only the tasks that have status CREATED will be migrated.
- the tasks will be migrated by default into the 'background' queue, but this depends on the config. If the task it's supported by the extension-task-queue he will go into the configurable queue.
- As you see after migrating the old task we updated his status to ARCHIVED.