### PR TITLE
Sqs removed profile

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label' => 'Task Queue',
     'description' => 'TAO specific Task Queue with custom GUI',
     'license' => 'GPL-2.0',
-    'version' => '0.8.0',
+    'version' => '0.8.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=5.8.0',

--- a/model/QueueBroker/SqsQueueBroker.php
+++ b/model/QueueBroker/SqsQueueBroker.php
@@ -73,8 +73,8 @@ class SqsQueueBroker extends AbstractQueueBroker
     public function __toPhpCode()
     {
         return 'new '. get_called_class() .'('
-            . \common_Utils::toHumanReadablePhpString($this->awsProfile)
-            . ', '
+            //. \common_Utils::toHumanReadablePhpString($this->awsProfile)
+            //. ', '
             . \common_Utils::toHumanReadablePhpString($this->cacheId)
             . ', '
             . \common_Utils::toHumanReadablePhpString($this->getNumberOfTasksToReceive())

--- a/model/QueueBroker/SqsQueueBroker.php
+++ b/model/QueueBroker/SqsQueueBroker.php
@@ -34,7 +34,6 @@ class SqsQueueBroker extends AbstractQueueBroker
 {
     const DEFAULT_AWS_CLIENT_KEY = 'generis/awsClient';
 
-    //private $awsProfile;
     private $cacheId;
 
     /**
@@ -54,27 +53,20 @@ class SqsQueueBroker extends AbstractQueueBroker
      * @param string $cacheServiceId
      * @param int $receiveTasks
      */
-    public function __construct(/*$awsProfile, */$cacheServiceId, $receiveTasks = 1)
+    public function __construct($cacheServiceId, $receiveTasks = 1)
     {
         parent::__construct($receiveTasks);
-
-        /*if (empty($awsProfile)) {
-            throw new \InvalidArgumentException("AWS profile needs to be set for ". __CLASS__);
-        }*/
 
         if (empty($cacheServiceId)) {
             throw new \InvalidArgumentException("Cache Service needs to be set for ". __CLASS__);
         }
 
-        //$this->awsProfile = $awsProfile;
         $this->cacheId = $cacheServiceId;
     }
 
     public function __toPhpCode()
     {
         return 'new '. get_called_class() .'('
-            //. \common_Utils::toHumanReadablePhpString($this->awsProfile)
-            //. ', '
             . \common_Utils::toHumanReadablePhpString($this->cacheId)
             . ', '
             . \common_Utils::toHumanReadablePhpString($this->getNumberOfTasksToReceive())
@@ -94,9 +86,7 @@ class SqsQueueBroker extends AbstractQueueBroker
             /** @var AwsClient $awsClient */
             $awsClient = $this->getServiceLocator()->get(self::DEFAULT_AWS_CLIENT_KEY);
 
-            $this->client = $awsClient->getSqsClient(/*[
-                'profile' => $this->awsProfile
-            ]*/);
+            $this->client = $awsClient->getSqsClient();
         }
 
         return $this->client;

--- a/model/QueueBroker/SqsQueueBroker.php
+++ b/model/QueueBroker/SqsQueueBroker.php
@@ -34,7 +34,7 @@ class SqsQueueBroker extends AbstractQueueBroker
 {
     const DEFAULT_AWS_CLIENT_KEY = 'generis/awsClient';
 
-    private $awsProfile;
+    //private $awsProfile;
     private $cacheId;
 
     /**
@@ -51,23 +51,22 @@ class SqsQueueBroker extends AbstractQueueBroker
     /**
      * SqsQueueBroker constructor.
      *
-     * @param string $awsProfile AWS profile
      * @param string $cacheServiceId
      * @param int $receiveTasks
      */
-    public function __construct($awsProfile, $cacheServiceId, $receiveTasks = 1)
+    public function __construct(/*$awsProfile, */$cacheServiceId, $receiveTasks = 1)
     {
         parent::__construct($receiveTasks);
 
-        if (empty($awsProfile)) {
+        /*if (empty($awsProfile)) {
             throw new \InvalidArgumentException("AWS profile needs to be set for ". __CLASS__);
-        }
+        }*/
 
         if (empty($cacheServiceId)) {
             throw new \InvalidArgumentException("Cache Service needs to be set for ". __CLASS__);
         }
 
-        $this->awsProfile = $awsProfile;
+        //$this->awsProfile = $awsProfile;
         $this->cacheId = $cacheServiceId;
     }
 
@@ -95,9 +94,9 @@ class SqsQueueBroker extends AbstractQueueBroker
             /** @var AwsClient $awsClient */
             $awsClient = $this->getServiceLocator()->get(self::DEFAULT_AWS_CLIENT_KEY);
 
-            $this->client = $awsClient->getSqsClient([
+            $this->client = $awsClient->getSqsClient(/*[
                 'profile' => $this->awsProfile
-            ]);
+            ]*/);
         }
 
         return $this->client;

--- a/scripts/tools/InitializeQueue.php
+++ b/scripts/tools/InitializeQueue.php
@@ -51,10 +51,9 @@ use Zend\ServiceManager\ServiceLocatorAwareTrait;
  * ```
  *
  * - Using SQS Queues. Every existing queue will be changed to use SqsQueueBroker. You can set the following parameters:
- *  - aws-profile: Required
  *  - receive: Optional (Maximum amount of tasks that can be received when polling the queue)
  * ```
- * $ sudo -u www-data php index.php 'oat\taoTaskQueue\scripts\tools\InitializeQueue' --broker=sqs --aws-profile=default --receive=10
+ * $ sudo -u www-data php index.php 'oat\taoTaskQueue\scripts\tools\InitializeQueue' --broker=sqs --receive=10
  * ```
  */
 class InitializeQueue extends InstallAction
@@ -67,7 +66,6 @@ class InitializeQueue extends InstallAction
 
     private $wantedBroker;
     private $persistenceId;
-    private $awsProfile;
     private $receive;
 
     public function __invoke($params)
@@ -94,7 +92,7 @@ class InitializeQueue extends InstallAction
                         break;
 
                     case self::BROKER_SQS:
-                        $broker = new SqsQueueBroker(/*$this->awsProfile,*/\common_cache_Cache::SERVICE_ID, $this->receive ?: 1);
+                        $broker = new SqsQueueBroker(\common_cache_Cache::SERVICE_ID, $this->receive ?: 1);
                         break;
                 }
 
@@ -148,10 +146,6 @@ class InitializeQueue extends InstallAction
                     $this->persistenceId = $value;
                     break;
 
-                /*case '--aws-profile':
-                    $this->awsProfile = $value;
-                    break;*/
-
                 case '--receive':
                     $this->receive = abs((int) $value);
                     break;
@@ -161,10 +155,6 @@ class InitializeQueue extends InstallAction
         if ($this->wantedBroker == self::BROKER_RDS && !$this->persistenceId) {
             throw new \InvalidArgumentException('Persistence id (--persistence=...) needs to be set for RDS.');
         }
-
-        /*if ($this->wantedBroker == self::BROKER_SQS && !$this->awsProfile) {
-            throw new \InvalidArgumentException('AWS profile (--aws-profile=...) needs to be set for SQS.');
-        }*/
     }
 }
 

--- a/scripts/tools/InitializeQueue.php
+++ b/scripts/tools/InitializeQueue.php
@@ -94,7 +94,7 @@ class InitializeQueue extends InstallAction
                         break;
 
                     case self::BROKER_SQS:
-                        $broker = new SqsQueueBroker($this->awsProfile, \common_cache_Cache::SERVICE_ID, $this->receive ?: 1);
+                        $broker = new SqsQueueBroker(/*$this->awsProfile,*/\common_cache_Cache::SERVICE_ID, $this->receive ?: 1);
                         break;
                 }
 
@@ -148,9 +148,9 @@ class InitializeQueue extends InstallAction
                     $this->persistenceId = $value;
                     break;
 
-                case '--aws-profile':
+                /*case '--aws-profile':
                     $this->awsProfile = $value;
-                    break;
+                    break;*/
 
                 case '--receive':
                     $this->receive = abs((int) $value);
@@ -162,9 +162,9 @@ class InitializeQueue extends InstallAction
             throw new \InvalidArgumentException('Persistence id (--persistence=...) needs to be set for RDS.');
         }
 
-        if ($this->wantedBroker == self::BROKER_SQS && !$this->awsProfile) {
+        /*if ($this->wantedBroker == self::BROKER_SQS && !$this->awsProfile) {
             throw new \InvalidArgumentException('AWS profile (--aws-profile=...) needs to be set for SQS.');
-        }
+        }*/
     }
 }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -85,6 +85,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('0.5.0');
         }
 
-        $this->skip('0.5.0', '0.8.0');
+        $this->skip('0.5.0', '0.8.1');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -72,7 +72,12 @@ class Updater extends common_ext_ExtensionUpdater
                 $toSchema = clone $fromSchema;
 
                 $table = $toSchema->getTable($taskLogService->getBroker()->getTableName());
-                $table->addColumn(TaskLogBrokerInterface::COLUMN_PARAMETERS, 'text', ["notnull" => false, "default" => null]);
+                try {
+                    $table->addColumn(TaskLogBrokerInterface::COLUMN_PARAMETERS, 'text', ["notnull" => false, "default" => null]);
+                }
+                catch (Exception $e) {
+                    // Prevents updater from crashing on already updated tables
+                }
 
                 $queries = $persistence->getPlatform()->getMigrateSchemaSql($fromSchema, $toSchema);
                 foreach ($queries as $query) {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -72,12 +72,8 @@ class Updater extends common_ext_ExtensionUpdater
                 $toSchema = clone $fromSchema;
 
                 $table = $toSchema->getTable($taskLogService->getBroker()->getTableName());
-                try {
-                    $table->addColumn(TaskLogBrokerInterface::COLUMN_PARAMETERS, 'text', ["notnull" => false, "default" => null]);
-                }
-                catch (Exception $e) {
-                    // Prevents updater from crashing on already updated tables
-                }
+                // Causes crash if column is already existing
+                $table->addColumn(TaskLogBrokerInterface::COLUMN_PARAMETERS, 'text', ["notnull" => false, "default" => null]);
 
                 $queries = $persistence->getPlatform()->getMigrateSchemaSql($fromSchema, $toSchema);
                 foreach ($queries as $query) {


### PR DESCRIPTION
I've removed profile reference from SqsBroker and Initialization script, so that it uses the default EC2 Role authentication approach which is only compatible with TAO AWS stacks.

http://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/credentials.html#instance-profile-credentials
http://docs.aws.amazon.com/aws-sdk-php/v2/guide/service-sqs.html

This is a kind of hack, but it worker (tested on luoat17exx).

Config before (I've manually chaged queue name to be unique):
```
<?php
/**
 * Default config header created during install
 */

return new oat\taoTaskQueue\model\QueueDispatcher(array(
    'queues' => array(
        new oat\taoTaskQueue\model\Queue('queue_luoat17exx', new oat\taoTaskQueue\model\QueueBroker\InMemoryQueueBroker(1), 1)
    ),
    'task_log' => 'taoTaskQueue/taskLog',
    'task_to_queue_associations' => array(
    )
));
```

```
luoat17exx-09a932a06640752ea:/var/www/html/tao$ sudo -u www-data php index.php 'oat\taoTaskQueue\scripts\tools\InitializeQueue' --broker=sqs
Initialization successful
```

Config after:
```
<?php
/**
 * Default config header created during install
 */

return new oat\taoTaskQueue\model\QueueDispatcher(array(
    'queues' => array(
        new oat\taoTaskQueue\model\Queue('queue_luoat17exx', new oat\taoTaskQueue\model\QueueBroker\SqsQueueBroker('generis/cache', 1), 1)
    ),
    'task_log' => 'taoTaskQueue/taskLog',
    'task_to_queue_associations' => array(
    )
));
```

The queue it has created in SQS:
`TQ_queue_luoat17exx`
