### PR TITLE
feature/TAO-7629 qunit 2 migration

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Task Queue',
     'description' => 'Extended Task Queue functionalities with custom GUI',
     'license' => 'GPL-2.0',
-    'version' => '1.4.0',
+    'version' => '1.4.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=5.8.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -250,6 +250,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.1.0');
         }
 
-        $this->skip('1.1.0', '1.4.0');
+        $this->skip('1.1.0', '1.4.1');
     }
 }

--- a/views/js/test/component/listing/element/test.html
+++ b/views/js/test/component/listing/element/test.html
@@ -7,8 +7,8 @@
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
         <link rel="stylesheet" type="text/css" href="js/ui/resource/css/selector.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="listing/element.js"></script>
         <script  type="text/javascript">

--- a/views/js/test/component/listing/element/test.js
+++ b/views/js/test/component/listing/element/test.js
@@ -15,68 +15,70 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define([
+define( [
+    
     'jquery',
     'lodash',
     'taoTaskQueue/component/listing/element'
-], function($, _, taskElementFactory) {
+], function(  $, _, taskElementFactory ) {
     'use strict';
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('module', function(assert) {
-        QUnit.expect(3);
+    QUnit.test( 'module', function( assert ) {
+        assert.expect( 3 );
 
-        assert.equal(typeof taskElementFactory, 'function', "The taskElementFactory module exposes a function");
-        assert.equal(typeof taskElementFactory(), 'object', "The taskElementFactory produces an object");
-        assert.notStrictEqual(taskElementFactory(), taskElementFactory(), "The taskElementFactory provides a different object on each call");
-    });
+        assert.equal( typeof taskElementFactory, 'function', 'The taskElementFactory module exposes a function' );
+        assert.equal( typeof taskElementFactory(), 'object', 'The taskElementFactory produces an object' );
+        assert.notStrictEqual( taskElementFactory(), taskElementFactory(), 'The taskElementFactory provides a different object on each call' );
+    } );
 
-    QUnit.cases([
-        { title : 'init' },
-        { title : 'destroy' },
-        { title : 'render' },
-        { title : 'show' },
-        { title : 'hide' },
-        { title : 'enable' },
-        { title : 'disable' },
-        { title : 'is' },
-        { title : 'setState' },
-        { title : 'getContainer' },
-        { title : 'getElement' },
-        { title : 'getTemplate' },
-        { title : 'setTemplate' },
-    ]).test('Component API ', function(data, assert) {
+    QUnit.cases.init( [
+        { title: 'init' },
+        { title: 'destroy' },
+        { title: 'render' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' },
+        { title: 'is' },
+        { title: 'setState' },
+        { title: 'getContainer' },
+        { title: 'getElement' },
+        { title: 'getTemplate' },
+        { title: 'setTemplate' }
+    ] ).test( 'Component API ', function( data, assert ) {
         var instance = taskElementFactory();
-        assert.equal(typeof instance[data.title], 'function', 'The element exposes the component method "' + data.title);
-    });
+        assert.equal( typeof instance[ data.title ], 'function', 'The element exposes the component method "' + data.title );
+    } );
 
-    QUnit.cases([
-        { title : 'on' },
-        { title : 'off' },
-        { title : 'trigger' },
-        { title : 'before' },
-        { title : 'after' },
-    ]).test('Eventifier API ', function(data, assert) {
+    QUnit.cases.init( [
+        { title: 'on' },
+        { title: 'off' },
+        { title: 'trigger' },
+        { title: 'before' },
+        { title: 'after' }
+    ] ).test( 'Eventifier API ', function( data, assert ) {
         var instance = taskElementFactory();
-        assert.equal(typeof instance[data.title], 'function', 'The element exposes the eventifier method "' + data.title);
-    });
+        assert.equal( typeof instance[ data.title ], 'function', 'The element exposes the eventifier method "' + data.title );
+    } );
 
-    QUnit.cases([
-        { title : 'getId' },
-        { title : 'getStatus' },
-        { title : 'getData' },
-        { title : 'update' },
-        { title : 'highlight' },
-        { title : 'setStatus' },
-        { title : 'getData' },
-    ]).test('Instance API ', function(data, assert) {
+    QUnit.cases.init( [
+        { title: 'getId' },
+        { title: 'getStatus' },
+        { title: 'getData' },
+        { title: 'update' },
+        { title: 'highlight' },
+        { title: 'setStatus' },
+        { title: 'getData' }
+    ] ).test( 'Instance API ', function( data, assert ) {
         var instance = taskElementFactory();
-        assert.equal(typeof instance[data.title], 'function', 'The element exposes the method "' + data.title);
-    });
+        assert.equal( typeof instance[ data.title ], 'function', 'The element exposes the method "' + data.title );
+    } );
 
-    QUnit.asyncTest('getId and getData', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'getId and getData', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -85,34 +87,35 @@ define([
             owner: 'userId',
             createdAt: '1512120107',
             updatedAt: '1512121107',
-            createdAtElapsed : 601,
-            updatedAtElapsed :26,
+            createdAtElapsed: 601,
+            updatedAtElapsed:26,
             hasFile: true,
             category: 'import',
-            report : {
-                type : 'success',
-                message : 'completed task rdf#i1508337970199318643',
-                data : null,
+            report: {
+                type: 'success',
+                message: 'completed task rdf#i1508337970199318643',
+                data: null,
                 children: []
             }
         };
 
-        QUnit.expect(3);
+        assert.expect( 3 );
 
-        taskElementFactory({}, data)
-            .on('render', function(){
-                assert.deepEqual(this.getData(), data, 'get data correct');
-                assert.equal(this.getId(), data.id, 'get id correct');
-                assert.equal(this.getStatus(), data.status, 'get status correct');
-                QUnit.start();
-            })
-            .render($container);
-    });
+        taskElementFactory( {}, data )
+            .on( 'render', function() {
+                assert.deepEqual( this.getData(), data, 'get data correct' );
+                assert.equal( this.getId(), data.id, 'get id correct' );
+                assert.equal( this.getStatus(), data.status, 'get status correct' );
+                ready();
+            } )
+            .render( $container );
+    } );
 
-    QUnit.module('Behavior');
+    QUnit.module( 'Behavior' );
 
-    QUnit.asyncTest('rendering and update', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'rendering and update', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -121,40 +124,41 @@ define([
             owner: 'userId',
             createdAt: '1512120107',
             updatedAt: '1512121107',
-            createdAtElapsed : 601,
-            updatedAtElapsed :26,
+            createdAtElapsed: 601,
+            updatedAtElapsed:26,
             hasFile: true,
             category: 'import',
-            report : {
-                type : 'success',
-                message : 'completed task rdf#i1508337970199318643',
-                data : null,
+            report: {
+                type: 'success',
+                message: 'completed task rdf#i1508337970199318643',
+                data: null,
                 children: []
             }
         };
 
-        QUnit.expect(7);
+        assert.expect( 7 );
 
-        taskElementFactory({}, data)
-            .on('render', function(){
+        taskElementFactory( {}, data )
+            .on( 'render', function() {
                 var $component = this.getElement();
-                assert.ok(true);
+                assert.ok( true );
 
-                assert.equal($component.find('.label').text(), 'Task label', 'the task label is correct');
-                assert.equal($component.find('.time').text(), 'Started 10 minutes ago', 'the task label is correct');
-                assert.ok($component.find('.shape > span').hasClass('icon-import'), 'icon correct');
+                assert.equal( $component.find( '.label' ).text(), 'Task label', 'the task label is correct' );
+                assert.equal( $component.find( '.time' ).text(), 'Started 10 minutes ago', 'the task label is correct' );
+                assert.ok( $component.find( '.shape > span' ).hasClass( 'icon-import' ), 'icon correct' );
 
                 assert.ok(!$component.find('[data-role="download"]').is(':visible'));
                 assert.ok(!$component.find('[data-role="report"]').is(':visible'));
                 assert.ok(!$component.find('[data-role="remove"]').is(':visible'));
 
-                QUnit.start();
-            })
-            .render($container);
-    });
+                ready();
+            } )
+            .render( $container );
+    } );
 
-    QUnit.asyncTest('render unknown category', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'render unknown category', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -163,67 +167,68 @@ define([
             owner: 'userId',
             createdAt: '1512120107',
             updatedAt: '1512121107',
-            createdAtElapsed : 601,
-            updatedAtElapsed :26,
+            createdAtElapsed: 601,
+            updatedAtElapsed:26,
             hasFile: true,
             category: 'unknown',
-            report : null
+            report: null
         };
 
-        QUnit.expect(23);
+        assert.expect( 23 );
 
-        taskElementFactory({}, data)
-            .on('render', function(){
+        taskElementFactory( {}, data )
+            .on( 'render', function() {
                 var $component = this.getElement();
-                assert.ok(true);
+                assert.ok( true );
 
-                assert.equal($component.find('.label').text(), 'Task label', 'the task label is correct');
-                assert.equal($component.find('.time').text(), 'Started 10 minutes ago', 'the task time is correct');
-                assert.ok($component.find('.shape > span').hasClass('icon-property-advanced'), 'unknown icon correct');
+                assert.equal( $component.find( '.label' ).text(), 'Task label', 'the task label is correct' );
+                assert.equal( $component.find( '.time' ).text(), 'Started 10 minutes ago', 'the task time is correct' );
+                assert.ok( $component.find( '.shape > span' ).hasClass( 'icon-property-advanced' ), 'unknown icon correct' );
 
-                assert.ok(!$component.find('[data-role="download"]').is(':visible'));
-                assert.ok(!$component.find('[data-role="report"]').is(':visible'));
-                assert.ok(!$component.find('[data-role="remove"]').is(':visible'));
+                assert.ok( !$component.find( '[data-role="download"]' ).is( ':visible' ) );
+                assert.ok( !$component.find( '[data-role="report"]' ).is( ':visible' ) );
+                assert.ok( !$component.find( '[data-role="remove"]' ).is( ':visible' ) );
 
-                this.update({
-                    status : 'in_progress'
-                });
+                this.update( {
+                    status: 'in_progress'
+                } );
 
-                assert.equal($component.find('.label').text(), 'Task label', 'the task label is correct');
-                assert.equal($component.find('.time').text(), 'Started 10 minutes ago', 'the task time is correct');
-                assert.ok($component.find('.shape > span').hasClass('icon-property-advanced'), 'unknown icon correct');
+                assert.equal( $component.find( '.label' ).text(), 'Task label', 'the task label is correct' );
+                assert.equal( $component.find( '.time' ).text(), 'Started 10 minutes ago', 'the task time is correct' );
+                assert.ok( $component.find( '.shape > span' ).hasClass( 'icon-property-advanced' ), 'unknown icon correct' );
 
-                assert.ok(!$component.find('[data-role="download"]').is(':visible'));
-                assert.ok(!$component.find('[data-role="report"]').is(':visible'));
-                assert.ok(!$component.find('[data-role="remove"]').is(':visible'));
+                assert.ok( !$component.find( '[data-role="download"]' ).is( ':visible' ) );
+                assert.ok( !$component.find( '[data-role="report"]' ).is( ':visible' ) );
+                assert.ok( !$component.find( '[data-role="remove"]' ).is( ':visible' ) );
 
-                this.update({
-                    status : 'failed'
-                });
+                this.update( {
+                    status: 'failed'
+                } );
 
-                assert.ok($component.find('[data-role="download"]').is(':visible'));
-                assert.ok($component.find('[data-role="report"]').is(':visible'));
-                assert.ok($component.find('[data-role="remove"]').is(':visible'));
-                assert.equal($component.find('.time').text(), 'Failed a few seconds ago', 'the task label is correct');
-                assert.ok($component.find('.shape > span').hasClass('icon-result-nok'), 'icon correct');
+                assert.ok( $component.find( '[data-role="download"]' ).is( ':visible' ) );
+                assert.ok( $component.find( '[data-role="report"]' ).is( ':visible' ) );
+                assert.ok( $component.find( '[data-role="remove"]' ).is( ':visible' ) );
+                assert.equal( $component.find( '.time' ).text(), 'Failed a few seconds ago', 'the task label is correct' );
+                assert.ok( $component.find( '.shape > span' ).hasClass( 'icon-result-nok' ), 'icon correct' );
 
-                this.update({
-                    status : 'completed'
-                });
+                this.update( {
+                    status: 'completed'
+                } );
 
-                assert.ok($component.find('[data-role="download"]').is(':visible'));
-                assert.ok($component.find('[data-role="report"]').is(':visible'));
-                assert.ok($component.find('[data-role="remove"]').is(':visible'));
-                assert.equal($component.find('.time').text(), 'Completed a few seconds ago', 'the task label is correct');
-                assert.ok($component.find('.shape > span').hasClass('icon-result-ok'), 'icon correct');
+                assert.ok( $component.find( '[data-role="download"]' ).is( ':visible' ) );
+                assert.ok( $component.find( '[data-role="report"]' ).is( ':visible' ) );
+                assert.ok( $component.find( '[data-role="remove"]' ).is( ':visible' ) );
+                assert.equal( $component.find( '.time' ).text(), 'Completed a few seconds ago', 'the task label is correct' );
+                assert.ok( $component.find( '.shape > span' ).hasClass( 'icon-result-ok' ), 'icon correct' );
 
-                QUnit.start();
-            })
-            .render($container);
-    });
+                ready();
+            } )
+            .render( $container );
+    } );
 
-    QUnit.asyncTest('Events', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'Events', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -232,40 +237,41 @@ define([
             owner: 'userId',
             createdAt: '1512120107',
             updatedAt: '1512121107',
-            createdAtElapsed : 601,
-            updatedAtElapsed :26,
+            createdAtElapsed: 601,
+            updatedAtElapsed:26,
             hasFile: true,
             category: 'import',
-            report : null
+            report: null
         };
 
-        QUnit.expect(3);
+        assert.expect( 3 );
 
-        taskElementFactory({}, data)
-            .on('download', function(){
-                assert.ok(true, 'download requested');
-            })
-            .on('report', function(){
-                assert.ok(true, 'report requested');
-            })
-            .on('report', function(){
-                assert.ok(true, 'remove requested');
-            })
-            .on('render', function(){
+        taskElementFactory( {}, data )
+            .on( 'download', function() {
+                assert.ok( true, 'download requested' );
+            } )
+            .on( 'report', function() {
+                assert.ok( true, 'report requested' );
+            } )
+            .on( 'report', function() {
+                assert.ok( true, 'remove requested' );
+            } )
+            .on( 'render', function() {
                 var $component = this.getElement();
-                $component.find('[data-role="download"]').click();
-                $component.find('[data-role="report"]').click();
-                $component.find('[data-role="remove"]').click();
+                $component.find( '[data-role="download"]' ).click();
+                $component.find( '[data-role="report"]' ).click();
+                $component.find( '[data-role="remove"]' ).click();
 
-                QUnit.start();
-            })
-            .render($container);
-    });
+                ready();
+            } )
+            .render( $container );
+    } );
 
-    QUnit.module('Visual');
+    QUnit.module( 'Visual' );
 
-    QUnit.asyncTest('visual test', function(assert) {
-        var $container = $('#visual');
+    QUnit.test( 'visual test', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#visual' );
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -274,24 +280,24 @@ define([
             owner: 'userId',
             createdAt: '1512120107',
             updatedAt: '1512121107',
-            createdAtElapsed : 601,
-            updatedAtElapsed :26,
+            createdAtElapsed: 601,
+            updatedAtElapsed:26,
             hasFile: true,
             category: 'import',
-            report : {
-                type : 'success',
-                message : 'completed task rdf#i1508337970199318643',
-                data : null,
+            report: {
+                type: 'success',
+                message: 'completed task rdf#i1508337970199318643',
+                data: null,
                 children: []
             }
         };
 
-        taskElementFactory({}, data)
-            .on('render', function(){
-                assert.ok(true);
-                QUnit.start();
-            })
-            .render($container);
-    });
+        taskElementFactory( {}, data )
+            .on( 'render', function() {
+                assert.ok( true );
+                ready();
+            } )
+            .render( $container );
+    } );
 
-});
+} );

--- a/views/js/test/component/listing/element/test.js
+++ b/views/js/test/component/listing/element/test.js
@@ -15,70 +15,70 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define( [
-    
+define([
+
     'jquery',
     'lodash',
     'taoTaskQueue/component/listing/element'
-], function(  $, _, taskElementFactory ) {
+], function($, _, taskElementFactory) {
     'use strict';
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'module', function( assert ) {
-        assert.expect( 3 );
+    QUnit.test('module', function(assert) {
+        assert.expect(3);
 
-        assert.equal( typeof taskElementFactory, 'function', 'The taskElementFactory module exposes a function' );
-        assert.equal( typeof taskElementFactory(), 'object', 'The taskElementFactory produces an object' );
-        assert.notStrictEqual( taskElementFactory(), taskElementFactory(), 'The taskElementFactory provides a different object on each call' );
-    } );
+        assert.equal(typeof taskElementFactory, 'function', 'The taskElementFactory module exposes a function');
+        assert.equal(typeof taskElementFactory(), 'object', 'The taskElementFactory produces an object');
+        assert.notStrictEqual(taskElementFactory(), taskElementFactory(), 'The taskElementFactory provides a different object on each call');
+    });
 
-    QUnit.cases.init( [
-        { title: 'init' },
-        { title: 'destroy' },
-        { title: 'render' },
-        { title: 'show' },
-        { title: 'hide' },
-        { title: 'enable' },
-        { title: 'disable' },
-        { title: 'is' },
-        { title: 'setState' },
-        { title: 'getContainer' },
-        { title: 'getElement' },
-        { title: 'getTemplate' },
-        { title: 'setTemplate' }
-    ] ).test( 'Component API ', function( data, assert ) {
+    QUnit.cases.init([
+        {title: 'init'},
+        {title: 'destroy'},
+        {title: 'render'},
+        {title: 'show'},
+        {title: 'hide'},
+        {title: 'enable'},
+        {title: 'disable'},
+        {title: 'is'},
+        {title: 'setState'},
+        {title: 'getContainer'},
+        {title: 'getElement'},
+        {title: 'getTemplate'},
+        {title: 'setTemplate'}
+    ]).test('Component API ', function(data, assert) {
         var instance = taskElementFactory();
-        assert.equal( typeof instance[ data.title ], 'function', 'The element exposes the component method "' + data.title );
-    } );
+        assert.equal(typeof instance[data.title], 'function', 'The element exposes the component method "' + data.title);
+    });
 
-    QUnit.cases.init( [
-        { title: 'on' },
-        { title: 'off' },
-        { title: 'trigger' },
-        { title: 'before' },
-        { title: 'after' }
-    ] ).test( 'Eventifier API ', function( data, assert ) {
+    QUnit.cases.init([
+        {title: 'on'},
+        {title: 'off'},
+        {title: 'trigger'},
+        {title: 'before'},
+        {title: 'after'}
+    ]).test('Eventifier API ', function(data, assert) {
         var instance = taskElementFactory();
-        assert.equal( typeof instance[ data.title ], 'function', 'The element exposes the eventifier method "' + data.title );
-    } );
+        assert.equal(typeof instance[data.title], 'function', 'The element exposes the eventifier method "' + data.title);
+    });
 
-    QUnit.cases.init( [
-        { title: 'getId' },
-        { title: 'getStatus' },
-        { title: 'getData' },
-        { title: 'update' },
-        { title: 'highlight' },
-        { title: 'setStatus' },
-        { title: 'getData' }
-    ] ).test( 'Instance API ', function( data, assert ) {
+    QUnit.cases.init([
+        {title: 'getId'},
+        {title: 'getStatus'},
+        {title: 'getData'},
+        {title: 'update'},
+        {title: 'highlight'},
+        {title: 'setStatus'},
+        {title: 'getData'}
+    ]).test('Instance API ', function(data, assert) {
         var instance = taskElementFactory();
-        assert.equal( typeof instance[ data.title ], 'function', 'The element exposes the method "' + data.title );
-    } );
+        assert.equal(typeof instance[data.title], 'function', 'The element exposes the method "' + data.title);
+    });
 
-    QUnit.test( 'getId and getData', function( assert ) {
+    QUnit.test('getId and getData', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -88,7 +88,7 @@ define( [
             createdAt: '1512120107',
             updatedAt: '1512121107',
             createdAtElapsed: 601,
-            updatedAtElapsed:26,
+            updatedAtElapsed: 26,
             hasFile: true,
             category: 'import',
             report: {
@@ -99,23 +99,23 @@ define( [
             }
         };
 
-        assert.expect( 3 );
+        assert.expect(3);
 
-        taskElementFactory( {}, data )
-            .on( 'render', function() {
-                assert.deepEqual( this.getData(), data, 'get data correct' );
-                assert.equal( this.getId(), data.id, 'get id correct' );
-                assert.equal( this.getStatus(), data.status, 'get status correct' );
+        taskElementFactory({}, data)
+            .on('render', function() {
+                assert.deepEqual(this.getData(), data, 'get data correct');
+                assert.equal(this.getId(), data.id, 'get id correct');
+                assert.equal(this.getStatus(), data.status, 'get status correct');
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-    QUnit.module( 'Behavior' );
+    QUnit.module('Behavior');
 
-    QUnit.test( 'rendering and update', function( assert ) {
+    QUnit.test('rendering and update', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -125,7 +125,7 @@ define( [
             createdAt: '1512120107',
             updatedAt: '1512121107',
             createdAtElapsed: 601,
-            updatedAtElapsed:26,
+            updatedAtElapsed: 26,
             hasFile: true,
             category: 'import',
             report: {
@@ -136,29 +136,29 @@ define( [
             }
         };
 
-        assert.expect( 7 );
+        assert.expect(7);
 
-        taskElementFactory( {}, data )
-            .on( 'render', function() {
+        taskElementFactory({}, data)
+            .on('render', function() {
                 var $component = this.getElement();
-                assert.ok( true );
+                assert.ok(true);
 
-                assert.equal( $component.find( '.label' ).text(), 'Task label', 'the task label is correct' );
-                assert.equal( $component.find( '.time' ).text(), 'Started 10 minutes ago', 'the task label is correct' );
-                assert.ok( $component.find( '.shape > span' ).hasClass( 'icon-import' ), 'icon correct' );
+                assert.equal($component.find('.label').text(), 'Task label', 'the task label is correct');
+                assert.equal($component.find('.time').text(), 'Started 10 minutes ago', 'the task label is correct');
+                assert.ok($component.find('.shape > span').hasClass('icon-import'), 'icon correct');
 
                 assert.ok(!$component.find('[data-role="download"]').is(':visible'));
                 assert.ok(!$component.find('[data-role="report"]').is(':visible'));
                 assert.ok(!$component.find('[data-role="remove"]').is(':visible'));
 
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-    QUnit.test( 'render unknown category', function( assert ) {
+    QUnit.test('render unknown category', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -168,67 +168,67 @@ define( [
             createdAt: '1512120107',
             updatedAt: '1512121107',
             createdAtElapsed: 601,
-            updatedAtElapsed:26,
+            updatedAtElapsed: 26,
             hasFile: true,
             category: 'unknown',
             report: null
         };
 
-        assert.expect( 23 );
+        assert.expect(23);
 
-        taskElementFactory( {}, data )
-            .on( 'render', function() {
+        taskElementFactory({}, data)
+            .on('render', function() {
                 var $component = this.getElement();
-                assert.ok( true );
+                assert.ok(true);
 
-                assert.equal( $component.find( '.label' ).text(), 'Task label', 'the task label is correct' );
-                assert.equal( $component.find( '.time' ).text(), 'Started 10 minutes ago', 'the task time is correct' );
-                assert.ok( $component.find( '.shape > span' ).hasClass( 'icon-property-advanced' ), 'unknown icon correct' );
+                assert.equal($component.find('.label').text(), 'Task label', 'the task label is correct');
+                assert.equal($component.find('.time').text(), 'Started 10 minutes ago', 'the task time is correct');
+                assert.ok($component.find('.shape > span').hasClass('icon-property-advanced'), 'unknown icon correct');
 
-                assert.ok( !$component.find( '[data-role="download"]' ).is( ':visible' ) );
-                assert.ok( !$component.find( '[data-role="report"]' ).is( ':visible' ) );
-                assert.ok( !$component.find( '[data-role="remove"]' ).is( ':visible' ) );
+                assert.ok(!$component.find('[data-role="download"]').is(':visible'));
+                assert.ok(!$component.find('[data-role="report"]').is(':visible'));
+                assert.ok(!$component.find('[data-role="remove"]').is(':visible'));
 
-                this.update( {
+                this.update({
                     status: 'in_progress'
-                } );
+                });
 
-                assert.equal( $component.find( '.label' ).text(), 'Task label', 'the task label is correct' );
-                assert.equal( $component.find( '.time' ).text(), 'Started 10 minutes ago', 'the task time is correct' );
-                assert.ok( $component.find( '.shape > span' ).hasClass( 'icon-property-advanced' ), 'unknown icon correct' );
+                assert.equal($component.find('.label').text(), 'Task label', 'the task label is correct');
+                assert.equal($component.find('.time').text(), 'Started 10 minutes ago', 'the task time is correct');
+                assert.ok($component.find('.shape > span').hasClass('icon-property-advanced'), 'unknown icon correct');
 
-                assert.ok( !$component.find( '[data-role="download"]' ).is( ':visible' ) );
-                assert.ok( !$component.find( '[data-role="report"]' ).is( ':visible' ) );
-                assert.ok( !$component.find( '[data-role="remove"]' ).is( ':visible' ) );
+                assert.ok(!$component.find('[data-role="download"]').is(':visible'));
+                assert.ok(!$component.find('[data-role="report"]').is(':visible'));
+                assert.ok(!$component.find('[data-role="remove"]').is(':visible'));
 
-                this.update( {
+                this.update({
                     status: 'failed'
-                } );
+                });
 
-                assert.ok( $component.find( '[data-role="download"]' ).is( ':visible' ) );
-                assert.ok( $component.find( '[data-role="report"]' ).is( ':visible' ) );
-                assert.ok( $component.find( '[data-role="remove"]' ).is( ':visible' ) );
-                assert.equal( $component.find( '.time' ).text(), 'Failed a few seconds ago', 'the task label is correct' );
-                assert.ok( $component.find( '.shape > span' ).hasClass( 'icon-result-nok' ), 'icon correct' );
+                assert.ok($component.find('[data-role="download"]').is(':visible'));
+                assert.ok($component.find('[data-role="report"]').is(':visible'));
+                assert.ok($component.find('[data-role="remove"]').is(':visible'));
+                assert.equal($component.find('.time').text(), 'Failed a few seconds ago', 'the task label is correct');
+                assert.ok($component.find('.shape > span').hasClass('icon-result-nok'), 'icon correct');
 
-                this.update( {
+                this.update({
                     status: 'completed'
-                } );
+                });
 
-                assert.ok( $component.find( '[data-role="download"]' ).is( ':visible' ) );
-                assert.ok( $component.find( '[data-role="report"]' ).is( ':visible' ) );
-                assert.ok( $component.find( '[data-role="remove"]' ).is( ':visible' ) );
-                assert.equal( $component.find( '.time' ).text(), 'Completed a few seconds ago', 'the task label is correct' );
-                assert.ok( $component.find( '.shape > span' ).hasClass( 'icon-result-ok' ), 'icon correct' );
+                assert.ok($component.find('[data-role="download"]').is(':visible'));
+                assert.ok($component.find('[data-role="report"]').is(':visible'));
+                assert.ok($component.find('[data-role="remove"]').is(':visible'));
+                assert.equal($component.find('.time').text(), 'Completed a few seconds ago', 'the task label is correct');
+                assert.ok($component.find('.shape > span').hasClass('icon-result-ok'), 'icon correct');
 
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-    QUnit.test( 'Events', function( assert ) {
+    QUnit.test('Events', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -238,40 +238,40 @@ define( [
             createdAt: '1512120107',
             updatedAt: '1512121107',
             createdAtElapsed: 601,
-            updatedAtElapsed:26,
+            updatedAtElapsed: 26,
             hasFile: true,
             category: 'import',
             report: null
         };
 
-        assert.expect( 3 );
+        assert.expect(3);
 
-        taskElementFactory( {}, data )
-            .on( 'download', function() {
-                assert.ok( true, 'download requested' );
-            } )
-            .on( 'report', function() {
-                assert.ok( true, 'report requested' );
-            } )
-            .on( 'report', function() {
-                assert.ok( true, 'remove requested' );
-            } )
-            .on( 'render', function() {
+        taskElementFactory({}, data)
+            .on('download', function() {
+                assert.ok(true, 'download requested');
+            })
+            .on('report', function() {
+                assert.ok(true, 'report requested');
+            })
+            .on('report', function() {
+                assert.ok(true, 'remove requested');
+            })
+            .on('render', function() {
                 var $component = this.getElement();
-                $component.find( '[data-role="download"]' ).click();
-                $component.find( '[data-role="report"]' ).click();
-                $component.find( '[data-role="remove"]' ).click();
+                $component.find('[data-role="download"]').click();
+                $component.find('[data-role="report"]').click();
+                $component.find('[data-role="remove"]').click();
 
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-    QUnit.module( 'Visual' );
+    QUnit.module('Visual');
 
-    QUnit.test( 'visual test', function( assert ) {
+    QUnit.test('visual test', function(assert) {
         var ready = assert.async();
-        var $container = $( '#visual' );
+        var $container = $('#visual');
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -281,7 +281,7 @@ define( [
             createdAt: '1512120107',
             updatedAt: '1512121107',
             createdAtElapsed: 601,
-            updatedAtElapsed:26,
+            updatedAtElapsed: 26,
             hasFile: true,
             category: 'import',
             report: {
@@ -292,12 +292,12 @@ define( [
             }
         };
 
-        taskElementFactory( {}, data )
-            .on( 'render', function() {
-                assert.ok( true );
+        taskElementFactory({}, data)
+            .on('render', function() {
+                assert.ok(true);
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-} );
+});

--- a/views/js/test/component/listing/list/test.html
+++ b/views/js/test/component/listing/list/test.html
@@ -7,8 +7,8 @@
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
         <link rel="stylesheet" type="text/css" href="js/ui/resource/css/selector.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="listing/list.js"></script>
         <script  type="text/javascript">

--- a/views/js/test/component/listing/list/test.js
+++ b/views/js/test/component/listing/list/test.js
@@ -15,83 +15,83 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define( [
+define([
 
     'jquery',
     'lodash',
     'ui/component',
     'taoTaskQueue/component/listing/list'
-], function(  $, _, componentFactory, taskListFactory ) {
+], function($, _, componentFactory, taskListFactory) {
     'use strict';
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'module', function( assert ) {
-        assert.expect( 3 );
+    QUnit.test('module', function(assert) {
+        assert.expect(3);
 
-        assert.equal( typeof taskListFactory, 'function', 'The taskListFactory module exposes a function' );
-        assert.equal( typeof taskListFactory(), 'object', 'The taskListFactory produces an object' );
-        assert.notStrictEqual( taskListFactory(), taskListFactory(), 'The taskListFactory provides a different object on each call' );
-    } );
+        assert.equal(typeof taskListFactory, 'function', 'The taskListFactory module exposes a function');
+        assert.equal(typeof taskListFactory(), 'object', 'The taskListFactory produces an object');
+        assert.notStrictEqual(taskListFactory(), taskListFactory(), 'The taskListFactory provides a different object on each call');
+    });
 
-    QUnit.cases.init( [
-        { title: 'init' },
-        { title: 'destroy' },
-        { title: 'render' },
-        { title: 'show' },
-        { title: 'hide' },
-        { title: 'enable' },
-        { title: 'disable' },
-        { title: 'is' },
-        { title: 'setState' },
-        { title: 'getContainer' },
-        { title: 'getElement' },
-        { title: 'getTemplate' },
-        { title: 'setTemplate' }
-    ] ).test( 'Component API ', function( data, assert ) {
+    QUnit.cases.init([
+        {title: 'init'},
+        {title: 'destroy'},
+        {title: 'render'},
+        {title: 'show'},
+        {title: 'hide'},
+        {title: 'enable'},
+        {title: 'disable'},
+        {title: 'is'},
+        {title: 'setState'},
+        {title: 'getContainer'},
+        {title: 'getElement'},
+        {title: 'getTemplate'},
+        {title: 'setTemplate'}
+    ]).test('Component API ', function(data, assert) {
         var instance = taskListFactory();
-        assert.equal( typeof instance[ data.title ], 'function', 'The list exposes the component method "' + data.title );
-    } );
+        assert.equal(typeof instance[data.title], 'function', 'The list exposes the component method "' + data.title);
+    });
 
-    QUnit.cases.init( [
-        { title: 'on' },
-        { title: 'off' },
-        { title: 'trigger' },
-        { title: 'before' },
-        { title: 'after' }
-    ] ).test( 'Eventifier API ', function( data, assert ) {
+    QUnit.cases.init([
+        {title: 'on'},
+        {title: 'off'},
+        {title: 'trigger'},
+        {title: 'before'},
+        {title: 'after'}
+    ]).test('Eventifier API ', function(data, assert) {
         var instance = taskListFactory();
-        assert.equal( typeof instance[ data.title ], 'function', 'The list exposes the eventifier method "' + data.title );
-    } );
+        assert.equal(typeof instance[data.title], 'function', 'The list exposes the eventifier method "' + data.title);
+    });
 
-    QUnit.cases.init( [
-        { title: 'removeElement' },
-        { title: 'insertElement' },
-        { title: 'setDetail' },
-        { title: 'hideDetail' },
-        { title: 'scrollToTop' },
-        { title: 'animateInsertion' }
-    ] ).test( 'Instance API ', function( data, assert ) {
+    QUnit.cases.init([
+        {title: 'removeElement'},
+        {title: 'insertElement'},
+        {title: 'setDetail'},
+        {title: 'hideDetail'},
+        {title: 'scrollToTop'},
+        {title: 'animateInsertion'}
+    ]).test('Instance API ', function(data, assert) {
         var instance = taskListFactory();
-        assert.equal( typeof instance[ data.title ], 'function', 'The list exposes the method "' + data.title );
-    } );
+        assert.equal(typeof instance[data.title], 'function', 'The list exposes the method "' + data.title);
+    });
 
-    QUnit.module( 'Methods' );
+    QUnit.module('Methods');
 
-    QUnit.test( 'insert and remove', function( assert ) {
+    QUnit.test('insert and remove', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
         taskListFactory()
-            .on( 'render', function() {
+            .on('render', function() {
                 var dummyListFactory = function dummyListFactory() {
                     var id;
-                    if ( !dummyListFactory.idCounter ) {
+                    if (!dummyListFactory.idCounter) {
                         dummyListFactory.idCounter = 0;
                     }
                     dummyListFactory.idCounter++;
                     id = dummyListFactory.idCounter;
 
-                    return componentFactory( {
+                    return componentFactory({
                         getId: function() {
                             return id;
                         }
@@ -101,45 +101,45 @@ define( [
                 };
 
                 var first = dummyListFactory();
-                this.insertElement( first );
-                this.insertElement( dummyListFactory() );
-                this.insertElement( dummyListFactory() );
-                this.insertElement( dummyListFactory() );
+                this.insertElement(first);
+                this.insertElement(dummyListFactory());
+                this.insertElement(dummyListFactory());
+                this.insertElement(dummyListFactory());
 
-                assert.ok( this.getElement().find( '.task-list' ).is( ':visible' ), 'list visible' );
-                assert.equal( this.getElement().find( '.task-list li' ).length, 4, 'has four element rendered' );
-                assert.equal( this.getElement().find( '.task-list li[data-id=1]' ).length, 1, 'found the element' );
-                assert.equal( this.getElement().find( '.task-list li[data-id=2]' ).length, 1, 'found the element' );
-                assert.equal( this.getElement().find( '.task-list li[data-id=3]' ).length, 1, 'found the element' );
-                assert.equal( this.getElement().find( '.task-list li[data-id=4]' ).length, 1, 'found the element' );
+                assert.ok(this.getElement().find('.task-list').is(':visible'), 'list visible');
+                assert.equal(this.getElement().find('.task-list li').length, 4, 'has four element rendered');
+                assert.equal(this.getElement().find('.task-list li[data-id=1]').length, 1, 'found the element');
+                assert.equal(this.getElement().find('.task-list li[data-id=2]').length, 1, 'found the element');
+                assert.equal(this.getElement().find('.task-list li[data-id=3]').length, 1, 'found the element');
+                assert.equal(this.getElement().find('.task-list li[data-id=4]').length, 1, 'found the element');
 
-                this.removeElement( first );
+                this.removeElement(first);
 
-                assert.equal( this.getElement().find( '.task-list li' ).length, 3, 'has four element rendered' );
-                assert.equal( this.getElement().find( '.task-list li[data-id=1]' ).length, 0, 'first element is gone' );
-                assert.equal( this.getElement().find( '.task-list li[data-id=2]' ).length, 1, 'found the element' );
-                assert.equal( this.getElement().find( '.task-list li[data-id=3]' ).length, 1, 'found the element' );
-                assert.equal( this.getElement().find( '.task-list li[data-id=4]' ).length, 1, 'found the element' );
+                assert.equal(this.getElement().find('.task-list li').length, 3, 'has four element rendered');
+                assert.equal(this.getElement().find('.task-list li[data-id=1]').length, 0, 'first element is gone');
+                assert.equal(this.getElement().find('.task-list li[data-id=2]').length, 1, 'found the element');
+                assert.equal(this.getElement().find('.task-list li[data-id=3]').length, 1, 'found the element');
+                assert.equal(this.getElement().find('.task-list li[data-id=4]').length, 1, 'found the element');
 
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-    QUnit.test( 'set and hide details', function( assert ) {
+    QUnit.test('set and hide details', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
         taskListFactory()
-            .on( 'render', function() {
+            .on('render', function() {
                 var dummyListFactory = function dummyListFactory() {
                     var id;
-                    if ( !dummyListFactory.idCounter ) {
+                    if (!dummyListFactory.idCounter) {
                         dummyListFactory.idCounter = 0;
                     }
                     dummyListFactory.idCounter++;
                     id = dummyListFactory.idCounter;
 
-                    return componentFactory( {
+                    return componentFactory({
                         getId: function() {
                             return id;
                         }
@@ -148,19 +148,19 @@ define( [
                     }).init();
                 };
 
-                assert.ok( this.getElement().find( '.task-list' ).is( ':visible' ), 'list visible' );
+                assert.ok(this.getElement().find('.task-list').is(':visible'), 'list visible');
 
-                this.setDetail( dummyListFactory(), true );
-                assert.ok( this.getElement().find( '.view-detail' ).is( ':visible' ), 'viewing detail' );
-                assert.ok( !this.getElement().find( '.task-list' ).is( ':visible' ), 'list hidden' );
+                this.setDetail(dummyListFactory(), true);
+                assert.ok(this.getElement().find('.view-detail').is(':visible'), 'viewing detail');
+                assert.ok(!this.getElement().find('.task-list').is(':visible'), 'list hidden');
 
                 this.hideDetail();
-                assert.ok( !this.getElement().find( '.view-detail' ).is( ':visible' ), 'detail hidden' );
-                assert.ok( this.getElement().find( '.task-list' ).is( ':visible' ), 'list shown' );
+                assert.ok(!this.getElement().find('.view-detail').is(':visible'), 'detail hidden');
+                assert.ok(this.getElement().find('.task-list').is(':visible'), 'list shown');
 
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-} );
+});

--- a/views/js/test/component/listing/list/test.js
+++ b/views/js/test/component/listing/list/test.js
@@ -15,82 +15,84 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define([
+define( [
+
     'jquery',
     'lodash',
     'ui/component',
     'taoTaskQueue/component/listing/list'
-], function($, _, componentFactory, taskListFactory) {
+], function(  $, _, componentFactory, taskListFactory ) {
     'use strict';
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('module', function(assert) {
-        QUnit.expect(3);
+    QUnit.test( 'module', function( assert ) {
+        assert.expect( 3 );
 
-        assert.equal(typeof taskListFactory, 'function', "The taskListFactory module exposes a function");
-        assert.equal(typeof taskListFactory(), 'object', "The taskListFactory produces an object");
-        assert.notStrictEqual(taskListFactory(), taskListFactory(), "The taskListFactory provides a different object on each call");
-    });
+        assert.equal( typeof taskListFactory, 'function', 'The taskListFactory module exposes a function' );
+        assert.equal( typeof taskListFactory(), 'object', 'The taskListFactory produces an object' );
+        assert.notStrictEqual( taskListFactory(), taskListFactory(), 'The taskListFactory provides a different object on each call' );
+    } );
 
-    QUnit.cases([
-        { title : 'init' },
-        { title : 'destroy' },
-        { title : 'render' },
-        { title : 'show' },
-        { title : 'hide' },
-        { title : 'enable' },
-        { title : 'disable' },
-        { title : 'is' },
-        { title : 'setState' },
-        { title : 'getContainer' },
-        { title : 'getElement' },
-        { title : 'getTemplate' },
-        { title : 'setTemplate' },
-    ]).test('Component API ', function(data, assert) {
+    QUnit.cases.init( [
+        { title: 'init' },
+        { title: 'destroy' },
+        { title: 'render' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' },
+        { title: 'is' },
+        { title: 'setState' },
+        { title: 'getContainer' },
+        { title: 'getElement' },
+        { title: 'getTemplate' },
+        { title: 'setTemplate' }
+    ] ).test( 'Component API ', function( data, assert ) {
         var instance = taskListFactory();
-        assert.equal(typeof instance[data.title], 'function', 'The list exposes the component method "' + data.title);
-    });
+        assert.equal( typeof instance[ data.title ], 'function', 'The list exposes the component method "' + data.title );
+    } );
 
-    QUnit.cases([
-        { title : 'on' },
-        { title : 'off' },
-        { title : 'trigger' },
-        { title : 'before' },
-        { title : 'after' },
-    ]).test('Eventifier API ', function(data, assert) {
+    QUnit.cases.init( [
+        { title: 'on' },
+        { title: 'off' },
+        { title: 'trigger' },
+        { title: 'before' },
+        { title: 'after' }
+    ] ).test( 'Eventifier API ', function( data, assert ) {
         var instance = taskListFactory();
-        assert.equal(typeof instance[data.title], 'function', 'The list exposes the eventifier method "' + data.title);
-    });
+        assert.equal( typeof instance[ data.title ], 'function', 'The list exposes the eventifier method "' + data.title );
+    } );
 
-    QUnit.cases([
-        { title : 'removeElement' },
-        { title : 'insertElement' },
-        { title : 'setDetail' },
-        { title : 'hideDetail' },
-        { title : 'scrollToTop' },
-        { title : 'animateInsertion' },
-    ]).test('Instance API ', function(data, assert) {
+    QUnit.cases.init( [
+        { title: 'removeElement' },
+        { title: 'insertElement' },
+        { title: 'setDetail' },
+        { title: 'hideDetail' },
+        { title: 'scrollToTop' },
+        { title: 'animateInsertion' }
+    ] ).test( 'Instance API ', function( data, assert ) {
         var instance = taskListFactory();
-        assert.equal(typeof instance[data.title], 'function', 'The list exposes the method "' + data.title);
-    });
+        assert.equal( typeof instance[ data.title ], 'function', 'The list exposes the method "' + data.title );
+    } );
 
-    QUnit.module('Methods');
+    QUnit.module( 'Methods' );
 
-    QUnit.asyncTest('insert and remove', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'insert and remove', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
         taskListFactory()
-            .on('render', function(){
-                var dummyListFactory = function dummyListFactory(){
+            .on( 'render', function() {
+                var dummyListFactory = function dummyListFactory() {
                     var id;
-                    if(!dummyListFactory.idCounter){
+                    if ( !dummyListFactory.idCounter ) {
                         dummyListFactory.idCounter = 0;
                     }
                     dummyListFactory.idCounter++;
                     id = dummyListFactory.idCounter;
 
-                    return componentFactory({
-                        getId : function(){
+                    return componentFactory( {
+                        getId: function() {
                             return id;
                         }
                     }).setTemplate(function(){
@@ -99,45 +101,46 @@ define([
                 };
 
                 var first = dummyListFactory();
-                this.insertElement(first);
-                this.insertElement(dummyListFactory());
-                this.insertElement(dummyListFactory());
-                this.insertElement(dummyListFactory());
+                this.insertElement( first );
+                this.insertElement( dummyListFactory() );
+                this.insertElement( dummyListFactory() );
+                this.insertElement( dummyListFactory() );
 
-                assert.ok(this.getElement().find('.task-list').is(':visible'), 'list visible');
-                assert.equal(this.getElement().find('.task-list li').length, 4, 'has four element rendered');
-                assert.equal(this.getElement().find('.task-list li[data-id=1]').length, 1, 'found the element');
-                assert.equal(this.getElement().find('.task-list li[data-id=2]').length, 1, 'found the element');
-                assert.equal(this.getElement().find('.task-list li[data-id=3]').length, 1, 'found the element');
-                assert.equal(this.getElement().find('.task-list li[data-id=4]').length, 1, 'found the element');
+                assert.ok( this.getElement().find( '.task-list' ).is( ':visible' ), 'list visible' );
+                assert.equal( this.getElement().find( '.task-list li' ).length, 4, 'has four element rendered' );
+                assert.equal( this.getElement().find( '.task-list li[data-id=1]' ).length, 1, 'found the element' );
+                assert.equal( this.getElement().find( '.task-list li[data-id=2]' ).length, 1, 'found the element' );
+                assert.equal( this.getElement().find( '.task-list li[data-id=3]' ).length, 1, 'found the element' );
+                assert.equal( this.getElement().find( '.task-list li[data-id=4]' ).length, 1, 'found the element' );
 
-                this.removeElement(first);
+                this.removeElement( first );
 
-                assert.equal(this.getElement().find('.task-list li').length, 3, 'has four element rendered');
-                assert.equal(this.getElement().find('.task-list li[data-id=1]').length, 0, 'first element is gone');
-                assert.equal(this.getElement().find('.task-list li[data-id=2]').length, 1, 'found the element');
-                assert.equal(this.getElement().find('.task-list li[data-id=3]').length, 1, 'found the element');
-                assert.equal(this.getElement().find('.task-list li[data-id=4]').length, 1, 'found the element');
+                assert.equal( this.getElement().find( '.task-list li' ).length, 3, 'has four element rendered' );
+                assert.equal( this.getElement().find( '.task-list li[data-id=1]' ).length, 0, 'first element is gone' );
+                assert.equal( this.getElement().find( '.task-list li[data-id=2]' ).length, 1, 'found the element' );
+                assert.equal( this.getElement().find( '.task-list li[data-id=3]' ).length, 1, 'found the element' );
+                assert.equal( this.getElement().find( '.task-list li[data-id=4]' ).length, 1, 'found the element' );
 
-                QUnit.start();
-            })
-            .render($container);
-    });
+                ready();
+            } )
+            .render( $container );
+    } );
 
-    QUnit.asyncTest('set and hide details', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'set and hide details', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
         taskListFactory()
-            .on('render', function(){
-                var dummyListFactory = function dummyListFactory(){
+            .on( 'render', function() {
+                var dummyListFactory = function dummyListFactory() {
                     var id;
-                    if(!dummyListFactory.idCounter){
+                    if ( !dummyListFactory.idCounter ) {
                         dummyListFactory.idCounter = 0;
                     }
                     dummyListFactory.idCounter++;
                     id = dummyListFactory.idCounter;
 
-                    return componentFactory({
-                        getId : function(){
+                    return componentFactory( {
+                        getId: function() {
                             return id;
                         }
                     }).setTemplate(function(){
@@ -145,19 +148,19 @@ define([
                     }).init();
                 };
 
-                assert.ok(this.getElement().find('.task-list').is(':visible'), 'list visible');
+                assert.ok( this.getElement().find( '.task-list' ).is( ':visible' ), 'list visible' );
 
-                this.setDetail(dummyListFactory(), true);
-                assert.ok(this.getElement().find('.view-detail').is(':visible'), 'viewing detail');
-                assert.ok(!this.getElement().find('.task-list').is(':visible'), 'list hidden');
+                this.setDetail( dummyListFactory(), true );
+                assert.ok( this.getElement().find( '.view-detail' ).is( ':visible' ), 'viewing detail' );
+                assert.ok( !this.getElement().find( '.task-list' ).is( ':visible' ), 'list hidden' );
 
                 this.hideDetail();
-                assert.ok(!this.getElement().find('.view-detail').is(':visible'), 'detail hidden');
-                assert.ok(this.getElement().find('.task-list').is(':visible'), 'list shown');
+                assert.ok( !this.getElement().find( '.view-detail' ).is( ':visible' ), 'detail hidden' );
+                assert.ok( this.getElement().find( '.task-list' ).is( ':visible' ), 'list shown' );
 
-                QUnit.start();
-            })
-            .render($container);
-    });
+                ready();
+            } )
+            .render( $container );
+    } );
 
-});
+} );

--- a/views/js/test/component/listing/report/test.html
+++ b/views/js/test/component/listing/report/test.html
@@ -7,8 +7,8 @@
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
         <link rel="stylesheet" type="text/css" href="js/ui/resource/css/selector.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="listing/report.js"></script>
         <script  type="text/javascript">

--- a/views/js/test/component/listing/report/test.js
+++ b/views/js/test/component/listing/report/test.js
@@ -15,64 +15,66 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define([
+define( [
+    
     'jquery',
     'lodash',
     'taoTaskQueue/component/listing/report'
-], function($, _, taskReportFactory) {
+], function(  $, _, taskReportFactory ) {
     'use strict';
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('module', function(assert) {
-        QUnit.expect(3);
+    QUnit.test( 'module', function( assert ) {
+        assert.expect( 3 );
 
-        assert.equal(typeof taskReportFactory, 'function', "The taskReportFactory module exposes a function");
-        assert.equal(typeof taskReportFactory(), 'object', "The taskReportFactory produces an object");
-        assert.notStrictEqual(taskReportFactory(), taskReportFactory(), "The taskReportFactory provides a different object on each call");
-    });
+        assert.equal( typeof taskReportFactory, 'function', 'The taskReportFactory module exposes a function' );
+        assert.equal( typeof taskReportFactory(), 'object', 'The taskReportFactory produces an object' );
+        assert.notStrictEqual( taskReportFactory(), taskReportFactory(), 'The taskReportFactory provides a different object on each call' );
+    } );
 
-    QUnit.cases([
-        { title : 'init' },
-        { title : 'destroy' },
-        { title : 'render' },
-        { title : 'show' },
-        { title : 'hide' },
-        { title : 'enable' },
-        { title : 'disable' },
-        { title : 'is' },
-        { title : 'setState' },
-        { title : 'getContainer' },
-        { title : 'getElement' },
-        { title : 'getTemplate' },
-        { title : 'setTemplate' },
-    ]).test('Component API ', function(data, assert) {
+    QUnit.cases.init( [
+        { title: 'init' },
+        { title: 'destroy' },
+        { title: 'render' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' },
+        { title: 'is' },
+        { title: 'setState' },
+        { title: 'getContainer' },
+        { title: 'getElement' },
+        { title: 'getTemplate' },
+        { title: 'setTemplate' }
+    ] ).test( 'Component API ', function( data, assert ) {
         var instance = taskReportFactory();
-        assert.equal(typeof instance[data.title], 'function', 'The report exposes the component method "' + data.title);
-    });
+        assert.equal( typeof instance[ data.title ], 'function', 'The report exposes the component method "' + data.title );
+    } );
 
-    QUnit.cases([
-        { title : 'on' },
-        { title : 'off' },
-        { title : 'trigger' },
-        { title : 'before' },
-        { title : 'after' },
-    ]).test('Eventifier API ', function(data, assert) {
+    QUnit.cases.init( [
+        { title: 'on' },
+        { title: 'off' },
+        { title: 'trigger' },
+        { title: 'before' },
+        { title: 'after' }
+    ] ).test( 'Eventifier API ', function( data, assert ) {
         var instance = taskReportFactory();
-        assert.equal(typeof instance[data.title], 'function', 'The report exposes the eventifier method "' + data.title);
-    });
+        assert.equal( typeof instance[ data.title ], 'function', 'The report exposes the eventifier method "' + data.title );
+    } );
 
-    QUnit.cases([
-        { title : 'update' },
-    ]).test('Instance API ', function(data, assert) {
+    QUnit.cases.init( [
+        { title: 'update' }
+    ] ).test( 'Instance API ', function( data, assert ) {
         var instance = taskReportFactory();
-        assert.equal(typeof instance[data.title], 'function', 'The report exposes the method "' + data.title);
-    });
+        assert.equal( typeof instance[ data.title ], 'function', 'The report exposes the method "' + data.title );
+    } );
 
-    QUnit.module('Rendering');
+    QUnit.module( 'Rendering' );
 
-    QUnit.asyncTest('without report', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'without report', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -81,113 +83,114 @@ define([
             owner: 'userId',
             createdAt: '1512120107',
             updatedAt: '1512121107',
-            createdAtElapsed : 601,
-            updatedAtElapsed :26,
+            createdAtElapsed: 601,
+            updatedAtElapsed:26,
             hasFile: true,
             category: 'import',
-            report : {
-                type : 'success',
-                message : 'completed task rdf#i1508337970199318643',
-                data : null,
+            report: {
+                type: 'success',
+                message: 'completed task rdf#i1508337970199318643',
+                data: null,
                 children: []
             }
         };
 
-        QUnit.expect(3);
+        assert.expect( 3 );
 
-        taskReportFactory({}, data)
-            .on('render', function(){
-                assert.equal(this.getElement().get(0), $container.find('.task-detail-element').get(0), 'component properly rendered');
-                assert.equal(this.getElement().find('.detail-description .label').text(), data.taskLabel,'the title is correct');
-                assert.ok(this.getElement().find('.no-detail').is(':visible'), 'the no-detail message is displayed');
-                QUnit.start();
-            })
-            .render($container);
-    });
+        taskReportFactory( {}, data )
+            .on( 'render', function() {
+                assert.equal( this.getElement().get( 0 ), $container.find( '.task-detail-element' ).get( 0 ), 'component properly rendered' );
+                assert.equal( this.getElement().find( '.detail-description .label' ).text(), data.taskLabel, 'the title is correct' );
+                assert.ok( this.getElement().find( '.no-detail' ).is( ':visible' ), 'the no-detail message is displayed' );
+                ready();
+            } )
+            .render( $container );
+    } );
 
-    QUnit.asyncTest('with report', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'with report', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
 
         var _sampleReport = {
-            "type": "warning",
-            "message": "<em>Data not imported. All records are <strong>invalid.</strong></em>",
-            "data": null,
-            "children": [{
-                "type": "error",
-                "message": "Row 1 Student Number Identifier: Duplicated student \"92001\"",
-                "data": null,
-                "children": [{
-                    "type": "error",
-                    "message": "This is but a sub-report Z",
-                    "data": null,
-                    "children": []
-                }]
+            'type': 'warning',
+            'message': '<em>Data not imported. All records are <strong>invalid.</strong></em>',
+            'data': null,
+            'children': [ {
+                'type': 'error',
+                'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
+                'data': null,
+                'children': [ {
+                    'type': 'error',
+                    'message': 'This is but a sub-report Z',
+                    'data': null,
+                    'children': []
+                } ]
             }, {
-                "type": "success",
-                "message": "Row 2 Student Number Identifier OK",
-                "data": null,
-                "children": [{
-                    "type": "success",
-                    "message": "This is but a sub-report A",
-                    "data": null,
-                    "children": []
+                'type': 'success',
+                'message': 'Row 2 Student Number Identifier OK',
+                'data': null,
+                'children': [ {
+                    'type': 'success',
+                    'message': 'This is but a sub-report A',
+                    'data': null,
+                    'children': []
                 }, {
-                    "type": "info",
-                    "message": "This is but a sub-report B",
-                    "data": null,
-                    "children": []
-                }]
-            },{
-                "type": "error",
-                "message": "Row 1 Student Number Identifier: Duplicated student \"92001\"",
-                "data": null,
-                "children": [{
-                    "type": "error",
-                    "message": "This is but a sub-report Z",
-                    "data": null,
-                    "children": []
-                }]
+                    'type': 'info',
+                    'message': 'This is but a sub-report B',
+                    'data': null,
+                    'children': []
+                } ]
             }, {
-                "type": "success",
-                "message": "Row 2 Student Number Identifier OK",
-                "data": null,
-                "children": [{
-                    "type": "success",
-                    "message": "This is but a sub-report A",
-                    "data": null,
-                    "children": []
-                }, {
-                    "type": "info",
-                    "message": "This is but a sub-report B",
-                    "data": null,
-                    "children": []
-                }]
-            },{
-                "type": "error",
-                "message": "Row 1 Student Number Identifier: Duplicated student \"92001\"",
-                "data": null,
-                "children": [{
-                    "type": "error",
-                    "message": "This is but a sub-report Z",
-                    "data": null,
-                    "children": []
-                }]
+                'type': 'error',
+                'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
+                'data': null,
+                'children': [ {
+                    'type': 'error',
+                    'message': 'This is but a sub-report Z',
+                    'data': null,
+                    'children': []
+                } ]
             }, {
-                "type": "success",
-                "message": "Row 2 Student Number Identifier OK",
-                "data": null,
-                "children": [{
-                    "type": "success",
-                    "message": "This is but a sub-report A",
-                    "data": null,
-                    "children": []
+                'type': 'success',
+                'message': 'Row 2 Student Number Identifier OK',
+                'data': null,
+                'children': [ {
+                    'type': 'success',
+                    'message': 'This is but a sub-report A',
+                    'data': null,
+                    'children': []
                 }, {
-                    "type": "info",
-                    "message": "This is but a sub-report B",
-                    "data": null,
-                    "children": []
-                }]
-            }]
+                    'type': 'info',
+                    'message': 'This is but a sub-report B',
+                    'data': null,
+                    'children': []
+                } ]
+            }, {
+                'type': 'error',
+                'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
+                'data': null,
+                'children': [ {
+                    'type': 'error',
+                    'message': 'This is but a sub-report Z',
+                    'data': null,
+                    'children': []
+                } ]
+            }, {
+                'type': 'success',
+                'message': 'Row 2 Student Number Identifier OK',
+                'data': null,
+                'children': [ {
+                    'type': 'success',
+                    'message': 'This is but a sub-report A',
+                    'data': null,
+                    'children': []
+                }, {
+                    'type': 'info',
+                    'message': 'This is but a sub-report B',
+                    'data': null,
+                    'children': []
+                } ]
+            } ]
         };
         var data = {
             id: 'rdf#i1508337970190342',
@@ -197,35 +200,36 @@ define([
             owner: 'userId',
             createdAt: '1512124107',
             updatedAt: '1512125107',
-            createdAtElapsed : 61,
-            updatedAtElapsed :101,
+            createdAtElapsed: 61,
+            updatedAtElapsed:101,
             hasFile: true,
             category: 'export',
-            report : {
-                type : 'error',
-                message : 'running task rdf#i1508337970190342',
-                data : null,
-                children: [_sampleReport]
+            report: {
+                type: 'error',
+                message: 'running task rdf#i1508337970190342',
+                data: null,
+                children: [ _sampleReport ]
             }
         };
 
-        QUnit.expect(4);
+        assert.expect( 4 );
 
-        taskReportFactory({}, data)
-            .on('render', function(){
+        taskReportFactory( {}, data )
+            .on( 'render', function() {
 
-                assert.equal(this.getElement().get(0), $container.find('.task-detail-element').get(0), 'component properly rendered');
-                assert.ok(!this.getElement().find('.no-detail').is(':visible'), 'the no-detail message is hidden');
-                assert.equal(this.getElement().find('.detail-description .label').text(), data.taskLabel,'the title is correct');
-                assert.equal(this.getElement().find('.detail-body .component-report').length, 1, 'report generated');
+                assert.equal( this.getElement().get( 0 ), $container.find( '.task-detail-element' ).get( 0 ), 'component properly rendered' );
+                assert.ok( !this.getElement().find( '.no-detail' ).is( ':visible' ), 'the no-detail message is hidden' );
+                assert.equal( this.getElement().find( '.detail-description .label' ).text(), data.taskLabel, 'the title is correct' );
+                assert.equal( this.getElement().find( '.detail-body .component-report' ).length, 1, 'report generated' );
 
-                QUnit.start();
-            })
-            .render($container);
-    });
+                ready();
+            } )
+            .render( $container );
+    } );
 
-    QUnit.asyncTest('event', function(assert) {
-        var $container = $('#qunit-fixture');
+    QUnit.test( 'event', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#qunit-fixture' );
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -234,117 +238,118 @@ define([
             owner: 'userId',
             createdAt: '1512120107',
             updatedAt: '1512121107',
-            createdAtElapsed : 601,
-            updatedAtElapsed :26,
+            createdAtElapsed: 601,
+            updatedAtElapsed:26,
             hasFile: true,
             category: 'import',
-            report : {
-                type : 'success',
-                message : 'completed task rdf#i1508337970199318643',
-                data : null,
+            report: {
+                type: 'success',
+                message: 'completed task rdf#i1508337970199318643',
+                data: null,
                 children: []
             }
         };
 
-        QUnit.expect(2);
+        assert.expect( 2 );
 
-        taskReportFactory({}, data)
-            .on('close', function(){
-                assert.ok(true, 'request close');
-                QUnit.start();
-            })
-            .on('render', function(){
+        taskReportFactory( {}, data )
+            .on( 'close', function() {
+                assert.ok( true, 'request close' );
+                ready();
+            } )
+            .on( 'render', function() {
                 assert.ok(this.getElement().find('[data-role="close"]').length, 'close button found');
                 this.getElement().find('[data-role="close"]').click();
-            })
-            .render($container);
-    });
+            } )
+            .render( $container );
+    } );
 
-    QUnit.module('Visual');
+    QUnit.module( 'Visual' );
 
-    QUnit.asyncTest('visual test', function(assert) {
-        var $container = $('#visual');
+    QUnit.test( 'visual test', function( assert ) {
+        var ready = assert.async();
+        var $container = $( '#visual' );
 
         var _sampleReport = {
-            "type": "warning",
-            "message": "<em>Data not imported. All records are <strong>invalid.</strong></em>",
-            "data": null,
-            "children": [{
-                "type": "error",
-                "message": "Row 1 Student Number Identifier: Duplicated student \"92001\"",
-                "data": null,
-                "children": [{
-                    "type": "error",
-                    "message": "This is but a sub-report Z",
-                    "data": null,
-                    "children": []
-                }]
+            'type': 'warning',
+            'message': '<em>Data not imported. All records are <strong>invalid.</strong></em>',
+            'data': null,
+            'children': [ {
+                'type': 'error',
+                'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
+                'data': null,
+                'children': [ {
+                    'type': 'error',
+                    'message': 'This is but a sub-report Z',
+                    'data': null,
+                    'children': []
+                } ]
             }, {
-                "type": "success",
-                "message": "Row 2 Student Number Identifier OK",
-                "data": null,
-                "children": [{
-                    "type": "success",
-                    "message": "This is but a sub-report A",
-                    "data": null,
-                    "children": []
+                'type': 'success',
+                'message': 'Row 2 Student Number Identifier OK',
+                'data': null,
+                'children': [ {
+                    'type': 'success',
+                    'message': 'This is but a sub-report A',
+                    'data': null,
+                    'children': []
                 }, {
-                    "type": "info",
-                    "message": "This is but a sub-report B",
-                    "data": null,
-                    "children": []
-                }]
-            },{
-                "type": "error",
-                "message": "Row 1 Student Number Identifier: Duplicated student \"92001\"",
-                "data": null,
-                "children": [{
-                    "type": "error",
-                    "message": "This is but a sub-report Z",
-                    "data": null,
-                    "children": []
-                }]
+                    'type': 'info',
+                    'message': 'This is but a sub-report B',
+                    'data': null,
+                    'children': []
+                } ]
             }, {
-                "type": "success",
-                "message": "Row 2 Student Number Identifier OK",
-                "data": null,
-                "children": [{
-                    "type": "success",
-                    "message": "This is but a sub-report A",
-                    "data": null,
-                    "children": []
-                }, {
-                    "type": "info",
-                    "message": "This is but a sub-report B",
-                    "data": null,
-                    "children": []
-                }]
-            },{
-                "type": "error",
-                "message": "Row 1 Student Number Identifier: Duplicated student \"92001\"",
-                "data": null,
-                "children": [{
-                    "type": "error",
-                    "message": "This is but a sub-report Z",
-                    "data": null,
-                    "children": []
-                }]
+                'type': 'error',
+                'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
+                'data': null,
+                'children': [ {
+                    'type': 'error',
+                    'message': 'This is but a sub-report Z',
+                    'data': null,
+                    'children': []
+                } ]
             }, {
-                "type": "success",
-                "message": "Row 2 Student Number Identifier OK",
-                "data": null,
-                "children": [{
-                    "type": "success",
-                    "message": "This is but a sub-report A",
-                    "data": null,
-                    "children": []
+                'type': 'success',
+                'message': 'Row 2 Student Number Identifier OK',
+                'data': null,
+                'children': [ {
+                    'type': 'success',
+                    'message': 'This is but a sub-report A',
+                    'data': null,
+                    'children': []
                 }, {
-                    "type": "info",
-                    "message": "This is but a sub-report B",
-                    "data": null,
-                    "children": []
-                }]
-            }]
+                    'type': 'info',
+                    'message': 'This is but a sub-report B',
+                    'data': null,
+                    'children': []
+                } ]
+            }, {
+                'type': 'error',
+                'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
+                'data': null,
+                'children': [ {
+                    'type': 'error',
+                    'message': 'This is but a sub-report Z',
+                    'data': null,
+                    'children': []
+                } ]
+            }, {
+                'type': 'success',
+                'message': 'Row 2 Student Number Identifier OK',
+                'data': null,
+                'children': [ {
+                    'type': 'success',
+                    'message': 'This is but a sub-report A',
+                    'data': null,
+                    'children': []
+                }, {
+                    'type': 'info',
+                    'message': 'This is but a sub-report B',
+                    'data': null,
+                    'children': []
+                } ]
+            } ]
         };
         var data = {
             id: 'rdf#i1508337970190342',
@@ -354,24 +359,24 @@ define([
             owner: 'userId',
             createdAt: '1512124107',
             updatedAt: '1512125107',
-            createdAtElapsed : 61,
-            updatedAtElapsed :101,
+            createdAtElapsed: 61,
+            updatedAtElapsed:101,
             hasFile: true,
             category: 'export',
-            report : {
-                type : 'error',
-                message : 'running task rdf#i1508337970190342',
-                data : null,
-                children: [_sampleReport]
+            report: {
+                type: 'error',
+                message: 'running task rdf#i1508337970190342',
+                data: null,
+                children: [ _sampleReport ]
             }
         };
 
-        taskReportFactory({}, data)
-            .on('render', function(){
-                assert.ok(true, 'rendered');
-                QUnit.start();
-            })
-            .render($container);
-    });
+        taskReportFactory( {}, data )
+            .on( 'render', function() {
+                assert.ok( true, 'rendered' );
+                ready();
+            } )
+            .render( $container );
+    } );
 
-});
+} );

--- a/views/js/test/component/listing/report/test.js
+++ b/views/js/test/component/listing/report/test.js
@@ -15,66 +15,66 @@
  *
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
-define( [
-    
+define([
+
     'jquery',
     'lodash',
     'taoTaskQueue/component/listing/report'
-], function(  $, _, taskReportFactory ) {
+], function($, _, taskReportFactory) {
     'use strict';
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'module', function( assert ) {
-        assert.expect( 3 );
+    QUnit.test('module', function(assert) {
+        assert.expect(3);
 
-        assert.equal( typeof taskReportFactory, 'function', 'The taskReportFactory module exposes a function' );
-        assert.equal( typeof taskReportFactory(), 'object', 'The taskReportFactory produces an object' );
-        assert.notStrictEqual( taskReportFactory(), taskReportFactory(), 'The taskReportFactory provides a different object on each call' );
-    } );
+        assert.equal(typeof taskReportFactory, 'function', 'The taskReportFactory module exposes a function');
+        assert.equal(typeof taskReportFactory(), 'object', 'The taskReportFactory produces an object');
+        assert.notStrictEqual(taskReportFactory(), taskReportFactory(), 'The taskReportFactory provides a different object on each call');
+    });
 
-    QUnit.cases.init( [
-        { title: 'init' },
-        { title: 'destroy' },
-        { title: 'render' },
-        { title: 'show' },
-        { title: 'hide' },
-        { title: 'enable' },
-        { title: 'disable' },
-        { title: 'is' },
-        { title: 'setState' },
-        { title: 'getContainer' },
-        { title: 'getElement' },
-        { title: 'getTemplate' },
-        { title: 'setTemplate' }
-    ] ).test( 'Component API ', function( data, assert ) {
+    QUnit.cases.init([
+        {title: 'init'},
+        {title: 'destroy'},
+        {title: 'render'},
+        {title: 'show'},
+        {title: 'hide'},
+        {title: 'enable'},
+        {title: 'disable'},
+        {title: 'is'},
+        {title: 'setState'},
+        {title: 'getContainer'},
+        {title: 'getElement'},
+        {title: 'getTemplate'},
+        {title: 'setTemplate'}
+    ]).test('Component API ', function(data, assert) {
         var instance = taskReportFactory();
-        assert.equal( typeof instance[ data.title ], 'function', 'The report exposes the component method "' + data.title );
-    } );
+        assert.equal(typeof instance[data.title], 'function', 'The report exposes the component method "' + data.title);
+    });
 
-    QUnit.cases.init( [
-        { title: 'on' },
-        { title: 'off' },
-        { title: 'trigger' },
-        { title: 'before' },
-        { title: 'after' }
-    ] ).test( 'Eventifier API ', function( data, assert ) {
+    QUnit.cases.init([
+        {title: 'on'},
+        {title: 'off'},
+        {title: 'trigger'},
+        {title: 'before'},
+        {title: 'after'}
+    ]).test('Eventifier API ', function(data, assert) {
         var instance = taskReportFactory();
-        assert.equal( typeof instance[ data.title ], 'function', 'The report exposes the eventifier method "' + data.title );
-    } );
+        assert.equal(typeof instance[data.title], 'function', 'The report exposes the eventifier method "' + data.title);
+    });
 
-    QUnit.cases.init( [
-        { title: 'update' }
-    ] ).test( 'Instance API ', function( data, assert ) {
+    QUnit.cases.init([
+        {title: 'update'}
+    ]).test('Instance API ', function(data, assert) {
         var instance = taskReportFactory();
-        assert.equal( typeof instance[ data.title ], 'function', 'The report exposes the method "' + data.title );
-    } );
+        assert.equal(typeof instance[data.title], 'function', 'The report exposes the method "' + data.title);
+    });
 
-    QUnit.module( 'Rendering' );
+    QUnit.module('Rendering');
 
-    QUnit.test( 'without report', function( assert ) {
+    QUnit.test('without report', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -84,7 +84,7 @@ define( [
             createdAt: '1512120107',
             updatedAt: '1512121107',
             createdAtElapsed: 601,
-            updatedAtElapsed:26,
+            updatedAtElapsed: 26,
             hasFile: true,
             category: 'import',
             report: {
@@ -95,41 +95,41 @@ define( [
             }
         };
 
-        assert.expect( 3 );
+        assert.expect(3);
 
-        taskReportFactory( {}, data )
-            .on( 'render', function() {
-                assert.equal( this.getElement().get( 0 ), $container.find( '.task-detail-element' ).get( 0 ), 'component properly rendered' );
-                assert.equal( this.getElement().find( '.detail-description .label' ).text(), data.taskLabel, 'the title is correct' );
-                assert.ok( this.getElement().find( '.no-detail' ).is( ':visible' ), 'the no-detail message is displayed' );
+        taskReportFactory({}, data)
+            .on('render', function() {
+                assert.equal(this.getElement().get(0), $container.find('.task-detail-element').get(0), 'component properly rendered');
+                assert.equal(this.getElement().find('.detail-description .label').text(), data.taskLabel, 'the title is correct');
+                assert.ok(this.getElement().find('.no-detail').is(':visible'), 'the no-detail message is displayed');
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-    QUnit.test( 'with report', function( assert ) {
+    QUnit.test('with report', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
         var _sampleReport = {
             'type': 'warning',
             'message': '<em>Data not imported. All records are <strong>invalid.</strong></em>',
             'data': null,
-            'children': [ {
+            'children': [{
                 'type': 'error',
                 'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
                 'data': null,
-                'children': [ {
+                'children': [{
                     'type': 'error',
                     'message': 'This is but a sub-report Z',
                     'data': null,
                     'children': []
-                } ]
+                }]
             }, {
                 'type': 'success',
                 'message': 'Row 2 Student Number Identifier OK',
                 'data': null,
-                'children': [ {
+                'children': [{
                     'type': 'success',
                     'message': 'This is but a sub-report A',
                     'data': null,
@@ -139,22 +139,22 @@ define( [
                     'message': 'This is but a sub-report B',
                     'data': null,
                     'children': []
-                } ]
+                }]
             }, {
                 'type': 'error',
                 'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
                 'data': null,
-                'children': [ {
+                'children': [{
                     'type': 'error',
                     'message': 'This is but a sub-report Z',
                     'data': null,
                     'children': []
-                } ]
+                }]
             }, {
                 'type': 'success',
                 'message': 'Row 2 Student Number Identifier OK',
                 'data': null,
-                'children': [ {
+                'children': [{
                     'type': 'success',
                     'message': 'This is but a sub-report A',
                     'data': null,
@@ -164,22 +164,22 @@ define( [
                     'message': 'This is but a sub-report B',
                     'data': null,
                     'children': []
-                } ]
+                }]
             }, {
                 'type': 'error',
                 'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
                 'data': null,
-                'children': [ {
+                'children': [{
                     'type': 'error',
                     'message': 'This is but a sub-report Z',
                     'data': null,
                     'children': []
-                } ]
+                }]
             }, {
                 'type': 'success',
                 'message': 'Row 2 Student Number Identifier OK',
                 'data': null,
-                'children': [ {
+                'children': [{
                     'type': 'success',
                     'message': 'This is but a sub-report A',
                     'data': null,
@@ -189,8 +189,8 @@ define( [
                     'message': 'This is but a sub-report B',
                     'data': null,
                     'children': []
-                } ]
-            } ]
+                }]
+            }]
         };
         var data = {
             id: 'rdf#i1508337970190342',
@@ -201,35 +201,35 @@ define( [
             createdAt: '1512124107',
             updatedAt: '1512125107',
             createdAtElapsed: 61,
-            updatedAtElapsed:101,
+            updatedAtElapsed: 101,
             hasFile: true,
             category: 'export',
             report: {
                 type: 'error',
                 message: 'running task rdf#i1508337970190342',
                 data: null,
-                children: [ _sampleReport ]
+                children: [_sampleReport]
             }
         };
 
-        assert.expect( 4 );
+        assert.expect(4);
 
-        taskReportFactory( {}, data )
-            .on( 'render', function() {
+        taskReportFactory({}, data)
+            .on('render', function() {
 
-                assert.equal( this.getElement().get( 0 ), $container.find( '.task-detail-element' ).get( 0 ), 'component properly rendered' );
-                assert.ok( !this.getElement().find( '.no-detail' ).is( ':visible' ), 'the no-detail message is hidden' );
-                assert.equal( this.getElement().find( '.detail-description .label' ).text(), data.taskLabel, 'the title is correct' );
-                assert.equal( this.getElement().find( '.detail-body .component-report' ).length, 1, 'report generated' );
+                assert.equal(this.getElement().get(0), $container.find('.task-detail-element').get(0), 'component properly rendered');
+                assert.ok(!this.getElement().find('.no-detail').is(':visible'), 'the no-detail message is hidden');
+                assert.equal(this.getElement().find('.detail-description .label').text(), data.taskLabel, 'the title is correct');
+                assert.equal(this.getElement().find('.detail-body .component-report').length, 1, 'report generated');
 
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-    QUnit.test( 'event', function( assert ) {
+    QUnit.test('event', function(assert) {
         var ready = assert.async();
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
         var data = {
             id: 'rdf#i1508337970199318643',
             taskName: 'Task Name',
@@ -239,7 +239,7 @@ define( [
             createdAt: '1512120107',
             updatedAt: '1512121107',
             createdAtElapsed: 601,
-            updatedAtElapsed:26,
+            updatedAtElapsed: 26,
             hasFile: true,
             category: 'import',
             report: {
@@ -250,45 +250,45 @@ define( [
             }
         };
 
-        assert.expect( 2 );
+        assert.expect(2);
 
-        taskReportFactory( {}, data )
-            .on( 'close', function() {
-                assert.ok( true, 'request close' );
+        taskReportFactory({}, data)
+            .on('close', function() {
+                assert.ok(true, 'request close');
                 ready();
-            } )
-            .on( 'render', function() {
+            })
+            .on('render', function() {
                 assert.ok(this.getElement().find('[data-role="close"]').length, 'close button found');
                 this.getElement().find('[data-role="close"]').click();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-    QUnit.module( 'Visual' );
+    QUnit.module('Visual');
 
-    QUnit.test( 'visual test', function( assert ) {
+    QUnit.test('visual test', function(assert) {
         var ready = assert.async();
-        var $container = $( '#visual' );
+        var $container = $('#visual');
 
         var _sampleReport = {
             'type': 'warning',
             'message': '<em>Data not imported. All records are <strong>invalid.</strong></em>',
             'data': null,
-            'children': [ {
+            'children': [{
                 'type': 'error',
                 'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
                 'data': null,
-                'children': [ {
+                'children': [{
                     'type': 'error',
                     'message': 'This is but a sub-report Z',
                     'data': null,
                     'children': []
-                } ]
+                }]
             }, {
                 'type': 'success',
                 'message': 'Row 2 Student Number Identifier OK',
                 'data': null,
-                'children': [ {
+                'children': [{
                     'type': 'success',
                     'message': 'This is but a sub-report A',
                     'data': null,
@@ -298,22 +298,22 @@ define( [
                     'message': 'This is but a sub-report B',
                     'data': null,
                     'children': []
-                } ]
+                }]
             }, {
                 'type': 'error',
                 'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
                 'data': null,
-                'children': [ {
+                'children': [{
                     'type': 'error',
                     'message': 'This is but a sub-report Z',
                     'data': null,
                     'children': []
-                } ]
+                }]
             }, {
                 'type': 'success',
                 'message': 'Row 2 Student Number Identifier OK',
                 'data': null,
-                'children': [ {
+                'children': [{
                     'type': 'success',
                     'message': 'This is but a sub-report A',
                     'data': null,
@@ -323,22 +323,22 @@ define( [
                     'message': 'This is but a sub-report B',
                     'data': null,
                     'children': []
-                } ]
+                }]
             }, {
                 'type': 'error',
                 'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
                 'data': null,
-                'children': [ {
+                'children': [{
                     'type': 'error',
                     'message': 'This is but a sub-report Z',
                     'data': null,
                     'children': []
-                } ]
+                }]
             }, {
                 'type': 'success',
                 'message': 'Row 2 Student Number Identifier OK',
                 'data': null,
-                'children': [ {
+                'children': [{
                     'type': 'success',
                     'message': 'This is but a sub-report A',
                     'data': null,
@@ -348,8 +348,8 @@ define( [
                     'message': 'This is but a sub-report B',
                     'data': null,
                     'children': []
-                } ]
-            } ]
+                }]
+            }]
         };
         var data = {
             id: 'rdf#i1508337970190342',
@@ -360,23 +360,23 @@ define( [
             createdAt: '1512124107',
             updatedAt: '1512125107',
             createdAtElapsed: 61,
-            updatedAtElapsed:101,
+            updatedAtElapsed: 101,
             hasFile: true,
             category: 'export',
             report: {
                 type: 'error',
                 message: 'running task rdf#i1508337970190342',
                 data: null,
-                children: [ _sampleReport ]
+                children: [_sampleReport]
             }
         };
 
-        taskReportFactory( {}, data )
-            .on( 'render', function() {
-                assert.ok( true, 'rendered' );
+        taskReportFactory({}, data)
+            .on('render', function() {
+                assert.ok(true, 'rendered');
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-} );
+});

--- a/views/js/test/component/manager/test.html
+++ b/views/js/test/component/manager/test.html
@@ -7,8 +7,8 @@
         <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
         <link rel="stylesheet" type="text/css" href="css/tao-main-style.css">
         <link rel="stylesheet" type="text/css" href="js/ui/resource/css/selector.css">
-        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
         <script type="text/javascript" src="js/lib/qunit/qunit-parameterize.js"></script>
         <script type="text/javascript" src="js/lib/blanket/blanket.min.js" data-cover-flag="branchTracking" data-cover-only="manager.js"></script>
 

--- a/views/js/test/component/manager/test.js
+++ b/views/js/test/component/manager/test.js
@@ -16,93 +16,94 @@
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
 
-define([
+define( [
+    
     'jquery',
     'lodash',
     'taoTaskQueue/component/manager/manager'
-], function($, _, taskQueueManagerFactory) {
+], function(  $, _, taskQueueManagerFactory ) {
     'use strict';
 
     var _sampleReport = {
-        "type": "warning",
-        "message": "<em>Data not imported. All records are <strong>invalid.</strong></em>",
-        "data": null,
-        "children": [{
-            "type": "error",
-            "message": "Row 1 Student Number Identifier: Duplicated student \"92001\"",
-            "data": null,
-            "children": [{
-                "type": "error",
-                "message": "This is but a sub-report Z",
-                "data": null,
-                "children": []
-            }]
+        'type': 'warning',
+        'message': '<em>Data not imported. All records are <strong>invalid.</strong></em>',
+        'data': null,
+        'children': [ {
+            'type': 'error',
+            'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
+            'data': null,
+            'children': [ {
+                'type': 'error',
+                'message': 'This is but a sub-report Z',
+                'data': null,
+                'children': []
+            } ]
         }, {
-            "type": "success",
-            "message": "Row 2 Student Number Identifier OK",
-            "data": null,
-            "children": [{
-                "type": "success",
-                "message": "This is but a sub-report A",
-                "data": null,
-                "children": []
+            'type': 'success',
+            'message': 'Row 2 Student Number Identifier OK',
+            'data': null,
+            'children': [ {
+                'type': 'success',
+                'message': 'This is but a sub-report A',
+                'data': null,
+                'children': []
             }, {
-                "type": "info",
-                "message": "This is but a sub-report B",
-                "data": null,
-                "children": []
-            }]
-        },{
-            "type": "error",
-            "message": "Row 1 Student Number Identifier: Duplicated student \"92001\"",
-            "data": null,
-            "children": [{
-                "type": "error",
-                "message": "This is but a sub-report Z",
-                "data": null,
-                "children": []
-            }]
+                'type': 'info',
+                'message': 'This is but a sub-report B',
+                'data': null,
+                'children': []
+            } ]
         }, {
-            "type": "success",
-            "message": "Row 2 Student Number Identifier OK",
-            "data": null,
-            "children": [{
-                "type": "success",
-                "message": "This is but a sub-report A",
-                "data": null,
-                "children": []
-            }, {
-                "type": "info",
-                "message": "This is but a sub-report B",
-                "data": null,
-                "children": []
-            }]
-        },{
-            "type": "error",
-            "message": "Row 1 Student Number Identifier: Duplicated student \"92001\"",
-            "data": null,
-            "children": [{
-                "type": "error",
-                "message": "This is but a sub-report Z",
-                "data": null,
-                "children": []
-            }]
+            'type': 'error',
+            'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
+            'data': null,
+            'children': [ {
+                'type': 'error',
+                'message': 'This is but a sub-report Z',
+                'data': null,
+                'children': []
+            } ]
         }, {
-            "type": "success",
-            "message": "Row 2 Student Number Identifier OK",
-            "data": null,
-            "children": [{
-                "type": "success",
-                "message": "This is but a sub-report A",
-                "data": null,
-                "children": []
+            'type': 'success',
+            'message': 'Row 2 Student Number Identifier OK',
+            'data': null,
+            'children': [ {
+                'type': 'success',
+                'message': 'This is but a sub-report A',
+                'data': null,
+                'children': []
             }, {
-                "type": "info",
-                "message": "This is but a sub-report B",
-                "data": null,
-                "children": []
-            }]
-        }]
+                'type': 'info',
+                'message': 'This is but a sub-report B',
+                'data': null,
+                'children': []
+            } ]
+        }, {
+            'type': 'error',
+            'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
+            'data': null,
+            'children': [ {
+                'type': 'error',
+                'message': 'This is but a sub-report Z',
+                'data': null,
+                'children': []
+            } ]
+        }, {
+            'type': 'success',
+            'message': 'Row 2 Student Number Identifier OK',
+            'data': null,
+            'children': [ {
+                'type': 'success',
+                'message': 'This is but a sub-report A',
+                'data': null,
+                'children': []
+            }, {
+                'type': 'info',
+                'message': 'This is but a sub-report B',
+                'data': null,
+                'children': []
+            } ]
+        } ]
     };
     var _sampleLogCollection = [
         {
@@ -113,15 +114,15 @@ define([
             owner: 'userId',
             createdAt: '1512120107',
             updatedAt: '1512121107',
-            createdAtElapsed : 601,
-            updatedAtElapsed :26,
+            createdAtElapsed: 601,
+            updatedAtElapsed:26,
             hasFile: false,
             category: 'import',
             redirectUrl: 'http://tao.local/taoBackOffice/Redirector/redirectTaskToInstance?taskId=http%3A%2F%2Ftao%2Ftao.rdf%23i15366738451441107',
-            report : {
-                type : 'success',
-                message : 'completed task rdf#i1508337970199318643',
-                data : null,
+            report: {
+                type: 'success',
+                message: 'completed task rdf#i1508337970199318643',
+                data: null,
                 children: []
             }
         },
@@ -133,14 +134,14 @@ define([
             owner: 'userId',
             createdAt: '1512122107',
             updatedAt: '1512123107',
-            createdAtElapsed : 41,
-            updatedAtElapsed :626,
+            createdAtElapsed: 41,
+            updatedAtElapsed:626,
             hasFile: false,
             category: 'publish',
-            report : {
-                type : 'info',
-                message : 'running task rdf#i15083379701993186432222',
-                data : null,
+            report: {
+                type: 'info',
+                message: 'running task rdf#i15083379701993186432222',
+                data: null,
                 children: []
             }
         },
@@ -152,295 +153,302 @@ define([
             owner: 'userId',
             createdAt: '1512124107',
             updatedAt: '1512125107',
-            createdAtElapsed : 61,
-            updatedAtElapsed :101,
+            createdAtElapsed: 61,
+            updatedAtElapsed:101,
             hasFile: true,
             category: 'export',
-            report : {
-                type : 'error',
-                message : 'running task rdf#i1508337970190342',
-                data : null,
-                children: [_sampleReport]
+            report: {
+                type: 'error',
+                message: 'running task rdf#i1508337970190342',
+                data: null,
+                children: [ _sampleReport ]
             }
         }
     ];
 
-    QUnit.module('API');
+    QUnit.module( 'API' );
 
-    QUnit.test('module', function(assert) {
-        QUnit.expect(3);
+    QUnit.test( 'module', function( assert ) {
+        assert.expect( 3 );
 
-        assert.equal(typeof taskQueueManagerFactory, 'function', "The taskQueueManagerFactory module exposes a function");
-        assert.equal(typeof taskQueueManagerFactory(), 'object', "The taskQueueManagerFactory produces an object");
-        assert.notStrictEqual(taskQueueManagerFactory(), taskQueueManagerFactory(), "The taskQueueManagerFactory provides a different object on each call");
-    });
+        assert.equal( typeof taskQueueManagerFactory, 'function', 'The taskQueueManagerFactory module exposes a function' );
+        assert.equal( typeof taskQueueManagerFactory(), 'object', 'The taskQueueManagerFactory produces an object' );
+        assert.notStrictEqual( taskQueueManagerFactory(), taskQueueManagerFactory(), 'The taskQueueManagerFactory provides a different object on each call' );
+    } );
 
-    QUnit.cases([
-        { title : 'init' },
-        { title : 'destroy' },
-        { title : 'render' },
-        { title : 'show' },
-        { title : 'hide' },
-        { title : 'enable' },
-        { title : 'disable' },
-        { title : 'is' },
-        { title : 'setState' },
-        { title : 'getContainer' },
-        { title : 'getElement' },
-        { title : 'getTemplate' },
-        { title : 'setTemplate' },
-    ]).test('Component API ', function(data, assert) {
+    QUnit.cases.init( [
+        { title: 'init' },
+        { title: 'destroy' },
+        { title: 'render' },
+        { title: 'show' },
+        { title: 'hide' },
+        { title: 'enable' },
+        { title: 'disable' },
+        { title: 'is' },
+        { title: 'setState' },
+        { title: 'getContainer' },
+        { title: 'getElement' },
+        { title: 'getTemplate' },
+        { title: 'setTemplate' }
+    ] ).test( 'Component API ', function( data, assert ) {
         var instance = taskQueueManagerFactory();
         assert.equal(typeof instance[data.title], 'function', 'The taskQueueManager exposes the component method "' + data.title);
     });
 
-    QUnit.cases([
-        { title : 'on' },
-        { title : 'off' },
-        { title : 'trigger' },
-        { title : 'before' },
-        { title : 'after' },
-    ]).test('Eventifier API ', function(data, assert) {
+    QUnit.cases.init( [
+        { title: 'on' },
+        { title: 'off' },
+        { title: 'trigger' },
+        { title: 'before' },
+        { title: 'after' }
+    ] ).test( 'Eventifier API ', function( data, assert ) {
         var instance = taskQueueManagerFactory();
         assert.equal(typeof instance[data.title], 'function', 'The taskQueueManager exposes the eventifier method "' + data.title);
     });
 
-    QUnit.cases([
-        { title : 'getTaskElements' },
-        { title : 'showDetail' },
-        { title : 'addNewTask' },
-        { title : 'selfUpdateBadge' },
-        { title : 'loadData' },
-        { title : 'pulse' },
-        { title : 'showList' },
-        { title : 'hideList' },
-    ]).test('Instance API ', function(data, assert) {
+    QUnit.cases.init( [
+        { title: 'getTaskElements' },
+        { title: 'showDetail' },
+        { title: 'addNewTask' },
+        { title: 'selfUpdateBadge' },
+        { title: 'loadData' },
+        { title: 'pulse' },
+        { title: 'showList' },
+        { title: 'hideList' }
+    ] ).test( 'Instance API ', function( data, assert ) {
         var instance = taskQueueManagerFactory();
         assert.equal(typeof instance[data.title], 'function', 'The taskQueueManager exposes the method "' + data.title);
     });
 
-    QUnit.module('Behavior');
+    QUnit.module( 'Behavior' );
 
-    QUnit.asyncTest('rendering', function(assert) {
+    QUnit.test( 'rendering', function( assert ) {
+        var ready = assert.async();
 
-        var $container = $('#qunit-fixture');
+        var $container = $( '#qunit-fixture' );
 
-        taskQueueManagerFactory({}, _sampleLogCollection)
-            .on('render', function(){
+        taskQueueManagerFactory( {}, _sampleLogCollection )
+            .on( 'render', function() {
 
-                assert.equal(this.getElement().get(0), $container.find('.task-manager-container').get(0), 'component container found');
+                assert.equal( this.getElement().get( 0 ), $container.find( '.task-manager-container' ).get( 0 ), 'component container found' );
 
-                assert.equal(this.getElement().find('.badge-component').length, 1, 'badge component found');
-                assert.ok(this.getElement().find('.badge-component .loader').is(':visible'), 'the loader is on');
-                assert.ok(this.getElement().find('.badge-component .badge').hasClass('badge-warning'), 'the badge is displaying a warning');
-                assert.equal(this.getElement().find('.badge-component .badge').text(), '3', 'the badge value is correct');
+                assert.equal( this.getElement().find( '.badge-component' ).length, 1, 'badge component found' );
+                assert.ok( this.getElement().find( '.badge-component .loader' ).is( ':visible' ), 'the loader is on' );
+                assert.ok( this.getElement().find( '.badge-component .badge' ).hasClass( 'badge-warning' ), 'the badge is displaying a warning' );
+                assert.equal( this.getElement().find( '.badge-component .badge' ).text(), '3', 'the badge value is correct' );
 
-                assert.equal(this.getElement().find('.task-listing').length, 1, 'list component found');
-                assert.ok(!this.getElement().find('.task-listing').is(':visible'), 'list starts hidden');
-                assert.equal(this.getElement().find('.task-listing .task-list li').length, 3, 'list has 3 elements');
+                assert.equal( this.getElement().find( '.task-listing' ).length, 1, 'list component found' );
+                assert.ok( !this.getElement().find( '.task-listing' ).is( ':visible' ), 'list starts hidden' );
+                assert.equal( this.getElement().find( '.task-listing .task-list li' ).length, 3, 'list has 3 elements' );
 
-                QUnit.start();
-            })
-            .render($container);
-    });
+                ready();
+            } )
+            .render( $container );
+    } );
 
-    QUnit.asyncTest('show list & report', function(assert) {
+    QUnit.test( 'show list & report', function( assert ) {
+        var ready = assert.async();
 
-        var $container = $('#qunit-fixture');
+        var $container = $( '#qunit-fixture' );
 
-        taskQueueManagerFactory({}, _sampleLogCollection)
-            .on('render', function(){
+        taskQueueManagerFactory( {}, _sampleLogCollection )
+            .on( 'render', function() {
                 this.getElement().click();
-            })
-            .on('listshow', function(){
+            } )
+            .on( 'listshow', function() {
 
-                assert.ok(true, 'list shown');
+                assert.ok( true, 'list shown' );
 
-                this.showDetail(_sampleLogCollection[2]);
+                this.showDetail( _sampleLogCollection[ 2 ] );
 
-                assert.ok(!this.getElement().find('.task-listing .task-list').is(':visible'), 'the list is hidden');
-                assert.ok(this.getElement().find('.task-listing .view-detail').is(':visible'), 'the detail is displayed');
+                assert.ok( !this.getElement().find( '.task-listing .task-list' ).is( ':visible' ), 'the list is hidden' );
+                assert.ok( this.getElement().find( '.task-listing .view-detail' ).is( ':visible' ), 'the detail is displayed' );
 
-                //hide the list
+                //Hide the list
                 this.getElement().click();
-            })
-            .on('listhide', function(){
+            } )
+            .on( 'listhide', function() {
 
-                assert.ok(true, 'list hidden');
-                QUnit.start();
-            })
-            .render($container);
-    });
+                assert.ok( true, 'list hidden' );
+                ready();
+            } )
+            .render( $container );
+    } );
 
-    QUnit.asyncTest('show / hide list', function(assert) {
+    QUnit.test( 'show / hide list', function( assert ) {
+        var ready = assert.async();
 
-        var $container = $('#qunit-fixture');
+        var $container = $( '#qunit-fixture' );
 
-        QUnit.expect(5);
+        assert.expect( 5 );
 
-        taskQueueManagerFactory({}, _sampleLogCollection)
-            .on('render', function(){
-                assert.ok(!this.getElement().find('.task-listing .task-list').is(':visible'), 'the list is hidden by default');
+        taskQueueManagerFactory( {}, _sampleLogCollection )
+            .on( 'render', function() {
+                assert.ok( !this.getElement().find( '.task-listing .task-list' ).is( ':visible' ), 'the list is hidden by default' );
 
                 this.showList();
-            })
-            .on('listshow', function(){
-                assert.ok(true, 'listshown event has been triggered');
-                assert.ok(this.getElement().find('.task-listing .task-list').is(':visible'), 'the list is visible');
+            } )
+            .on( 'listshow', function() {
+                assert.ok( true, 'listshown event has been triggered' );
+                assert.ok( this.getElement().find( '.task-listing .task-list' ).is( ':visible' ), 'the list is visible' );
 
                 this.hideList();
-            })
-            .on('listhide', function(){
-                assert.ok(true, 'listhidden event has been triggered');
-                assert.ok(!this.getElement().find('.task-listing .task-list').is(':visible'), 'the list has been hidden');
+            } )
+            .on( 'listhide', function() {
+                assert.ok( true, 'listhidden event has been triggered' );
+                assert.ok( !this.getElement().find( '.task-listing .task-list' ).is( ':visible' ), 'the list has been hidden' );
 
-                QUnit.start();
-            })
-            .render($container);
-    });
+                ready();
+            } )
+            .render( $container );
+    } );
 
-    QUnit.asyncTest('removeAllFinished', function(assert) {
+    QUnit.test( 'removeAllFinished', function( assert ) {
+        var ready = assert.async();
 
-        var $container = $('#qunit-fixture');
+        var $container = $( '#qunit-fixture' );
 
-        taskQueueManagerFactory({}, _sampleLogCollection)
-            .on('render', function(){
+        taskQueueManagerFactory( {}, _sampleLogCollection )
+            .on( 'render', function() {
 
-                assert.equal(this.getElement().get(0), $container.find('.task-manager-container').get(0), 'component container found');
+                assert.equal( this.getElement().get( 0 ), $container.find( '.task-manager-container' ).get( 0 ), 'component container found' );
 
-                assert.equal(this.getElement().find('.badge-component').length, 1, 'badge component found');
-                assert.ok(this.getElement().find('.badge-component .loader').is(':visible'), 'the loader is on');
-                assert.ok(this.getElement().find('.badge-component .badge').hasClass('badge-warning'), 'the badge is displaying a warning');
-                assert.equal(this.getElement().find('.badge-component .badge').text(), '3', 'the badge value is correct');
+                assert.equal( this.getElement().find( '.badge-component' ).length, 1, 'badge component found' );
+                assert.ok( this.getElement().find( '.badge-component .loader' ).is( ':visible' ), 'the loader is on' );
+                assert.ok( this.getElement().find( '.badge-component .badge' ).hasClass( 'badge-warning' ), 'the badge is displaying a warning' );
+                assert.equal( this.getElement().find( '.badge-component .badge' ).text(), '3', 'the badge value is correct' );
 
-                assert.equal(this.getElement().find('.task-listing').length, 1, 'list component found');
-                assert.ok(!this.getElement().find('.task-listing').is(':visible'), 'list starts hidden');
-                assert.equal(this.getElement().find('.task-listing .task-list li').length, 3, 'list has 3 elements');
+                assert.equal( this.getElement().find( '.task-listing' ).length, 1, 'list component found' );
+                assert.ok( !this.getElement().find( '.task-listing' ).is( ':visible' ), 'list starts hidden' );
+                assert.equal( this.getElement().find( '.task-listing .task-list li' ).length, 3, 'list has 3 elements' );
 
                 this.removeAllFinished();
 
-                assert.ok(this.getElement().find('.badge-component .badge').hasClass('badge-info'), 'the badge is displaying a info');
-                assert.equal(this.getElement().find('.badge-component .badge').text(), '1', 'the badge value is correct');
+                assert.ok( this.getElement().find( '.badge-component .badge' ).hasClass( 'badge-info' ), 'the badge is displaying a info' );
+                assert.equal( this.getElement().find( '.badge-component .badge' ).text(), '1', 'the badge value is correct' );
 
-                QUnit.start();
-            })
-            .render($container);
-    });
+                ready();
+            } )
+            .render( $container );
+    } );
 
-    QUnit.asyncTest('clearAll', function(assert) {
+    QUnit.test( 'clearAll', function( assert ) {
+        var ready = assert.async();
 
-        var $container = $('#qunit-fixture');
+        var $container = $( '#qunit-fixture' );
 
-        taskQueueManagerFactory({}, _sampleLogCollection)
-            .on('render', function(){
+        taskQueueManagerFactory( {}, _sampleLogCollection )
+            .on( 'render', function() {
 
-                assert.equal(this.getElement().get(0), $container.find('.task-manager-container').get(0), 'component container found');
+                assert.equal( this.getElement().get( 0 ), $container.find( '.task-manager-container' ).get( 0 ), 'component container found' );
 
-                assert.equal(this.getElement().find('.badge-component').length, 1, 'badge component found');
-                assert.ok(this.getElement().find('.badge-component .loader').is(':visible'), 'the loader is on');
-                assert.ok(this.getElement().find('.badge-component .badge').hasClass('badge-warning'), 'the badge is displaying a warning');
-                assert.equal(this.getElement().find('.badge-component .badge').text(), '3', 'the badge value is correct');
+                assert.equal( this.getElement().find( '.badge-component' ).length, 1, 'badge component found' );
+                assert.ok( this.getElement().find( '.badge-component .loader' ).is( ':visible' ), 'the loader is on' );
+                assert.ok( this.getElement().find( '.badge-component .badge' ).hasClass( 'badge-warning' ), 'the badge is displaying a warning' );
+                assert.equal( this.getElement().find( '.badge-component .badge' ).text(), '3', 'the badge value is correct' );
 
-                assert.equal(this.getElement().find('.task-listing').length, 1, 'list component found');
-                assert.ok(!this.getElement().find('.task-listing').is(':visible'), 'list starts hidden');
-                assert.equal(this.getElement().find('.task-listing .task-list li').length, 3, 'list has 3 elements');
+                assert.equal( this.getElement().find( '.task-listing' ).length, 1, 'list component found' );
+                assert.ok( !this.getElement().find( '.task-listing' ).is( ':visible' ), 'list starts hidden' );
+                assert.equal( this.getElement().find( '.task-listing .task-list li' ).length, 3, 'list has 3 elements' );
 
-                assert.equal(this.getElement().find('.clear-all').length, 1, 'clear all button found');
+                assert.equal( this.getElement().find( '.clear-all' ).length, 1, 'clear all button found' );
 
-                //trigger cleanup
-                this.getElement().find('.clear-all').click();
+                //Trigger cleanup
+                this.getElement().find( '.clear-all' ).click();
 
-                assert.ok(this.getElement().find('.badge-component .badge').hasClass('badge-info'), 'the badge is displaying a info');
-                assert.equal(this.getElement().find('.badge-component .badge').text(), '1', 'the badge value is correct');
+                assert.ok( this.getElement().find( '.badge-component .badge' ).hasClass( 'badge-info' ), 'the badge is displaying a info' );
+                assert.equal( this.getElement().find( '.badge-component .badge' ).text(), '1', 'the badge value is correct' );
 
-                QUnit.start();
-            })
-            .render($container);
-    });
+                ready();
+            } )
+            .render( $container );
+    } );
 
-    QUnit.module('Visual');
+    QUnit.module( 'Visual' );
 
-    QUnit.asyncTest('playground', function(assert) {
+    QUnit.test( 'playground', function( assert ) {
+        var ready = assert.async();
 
         var taskManager;
-        var $container = $('#visual');
-        var $controls = $container.find('#controls');
-        var $list = $controls.find('ul');
+        var $container = $( '#visual' );
+        var $controls = $container.find( '#controls' );
+        var $list = $controls.find( 'ul' );
 
-        var getRandomValue = function getRandomValue(arr){
-            return arr[Math.floor(Math.random()*arr.length)];
+        var getRandomValue = function getRandomValue( arr ) {
+            return arr[ Math.floor( Math.random() * arr.length ) ];
         };
 
-        var updateTestTask = function updateTestTask(id, status){
+        var updateTestTask = function updateTestTask( id, status ) {
             var elements = taskManager.getTaskElements();
-            if(id && elements[id]){
-                elements[id].update({
+            if ( id && elements[ id ] ) {
+                elements[ id ].update( {
                     status: status,
-                    updatedAt : Math.floor(Date.now() / 1000),
-                    updatedAtElapsed : 0
-                });
+                    updatedAt: Math.floor( Date.now() / 1000 ),
+                    updatedAtElapsed: 0
+                } );
             }
-            taskManager.trigger('listchange');
+            taskManager.trigger( 'listchange' );
         };
 
-        var updateTaskList = function updateTaskList(){
+        var updateTaskList = function updateTaskList() {
             $list.empty();
             _.forEach(taskManager.getTaskElements(), function(task){
                 if(task.getStatus() === 'in_progress'){
                     $list.append('<li data-id="'+task.getId()+'"><span class="name">'+task.getData().taskLabel+'</span><a class="task-complete">complete it</a><a class="task-fail">fail it</a> </li>');
                 }
-            });
+            } );
         };
 
-        var createTask = function createTask(){
-            var timestamp = Math.floor(Date.now() / 1000);
-            var type = getRandomValue(['import', 'export', 'publish', 'transfer', 'create', 'update', 'delete']);
+        var createTask = function createTask() {
+            var timestamp = Math.floor( Date.now() / 1000 );
+            var type = getRandomValue( [ 'import', 'export', 'publish', 'transfer', 'create', 'update', 'delete' ] );
 
             return {
-                id: 'rdf#i'+(Math.floor(Math.random() * 123456789) +  123456789) ,
-                taskName: 'php/class/for/task/'+type,
-                taskLabel: 'Async ' +  type + ' ' + (Math.floor(Math.random() * 99) +  1),
+                id: 'rdf#i' + ( Math.floor( Math.random() * 123456789 ) +  123456789 ),
+                taskName: 'php/class/for/task/' + type,
+                taskLabel: 'Async ' +  type + ' ' + ( Math.floor( Math.random() * 99 ) +  1 ),
                 status: 'in_progress',
                 owner: 'userId',
                 createdAt: timestamp,
                 updatedAt: timestamp,
-                updatedAtElapsed : 0,
-                createdAtElapsed : 0,
-                file: getRandomValue([true, false]),
+                updatedAtElapsed: 0,
+                createdAtElapsed: 0,
+                file: getRandomValue( [ true, false ] ),
                 category: type,
-                report : null
+                report: null
             };
         };
 
-        $list.on('click', '.task-complete', function(){
-            var id = $(this).closest('li').data('id');
-            updateTestTask(id, 'completed');
+        $list.on( 'click', '.task-complete', function() {
+            var id = $( this ).closest( 'li' ).data( 'id' );
+            updateTestTask( id, 'completed' );
             updateTaskList();
 
-        }).on('click', '.task-fail', function(){
-            var id = $(this).closest('li').data('id');
-            updateTestTask(id, 'failed');
+        } ).on( 'click', '.task-fail', function() {
+            var id = $( this ).closest( 'li' ).data( 'id' );
+            updateTestTask( id, 'failed' );
             updateTaskList();
-        });
+        } );
 
-        taskManager = taskQueueManagerFactory({}, _sampleLogCollection)
-            .on('report', function(){
-                //fetch report
-                this.showDetail(_sampleLogCollection[2]);
-            })
-            .on('render', function(){
+        taskManager = taskQueueManagerFactory( {}, _sampleLogCollection )
+            .on( 'report', function() {
+
+                //Fetch report
+                this.showDetail( _sampleLogCollection[ 2 ] );
+            } )
+            .on( 'render', function() {
                 var self = this;
-                assert.ok(true);
+                assert.ok( true );
 
-                $controls.find('.add-task').click(function(){
-                    self.addNewTask(createTask(), true);
+                $controls.find( '.add-task' ).click( function() {
+                    self.addNewTask( createTask(), true );
                     updateTaskList();
-                });
+                } );
 
-                QUnit.start();
-            })
-            .render($container);
+                ready();
+            } )
+            .render( $container );
 
         updateTaskList();
-    });
-});
+    } );
+} );

--- a/views/js/test/component/manager/test.js
+++ b/views/js/test/component/manager/test.js
@@ -16,33 +16,33 @@
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  */
 
-define( [
-    
+define([
+
     'jquery',
     'lodash',
     'taoTaskQueue/component/manager/manager'
-], function(  $, _, taskQueueManagerFactory ) {
+], function($, _, taskQueueManagerFactory) {
     'use strict';
 
     var _sampleReport = {
         'type': 'warning',
         'message': '<em>Data not imported. All records are <strong>invalid.</strong></em>',
         'data': null,
-        'children': [ {
+        'children': [{
             'type': 'error',
             'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
             'data': null,
-            'children': [ {
+            'children': [{
                 'type': 'error',
                 'message': 'This is but a sub-report Z',
                 'data': null,
                 'children': []
-            } ]
+            }]
         }, {
             'type': 'success',
             'message': 'Row 2 Student Number Identifier OK',
             'data': null,
-            'children': [ {
+            'children': [{
                 'type': 'success',
                 'message': 'This is but a sub-report A',
                 'data': null,
@@ -52,22 +52,22 @@ define( [
                 'message': 'This is but a sub-report B',
                 'data': null,
                 'children': []
-            } ]
+            }]
         }, {
             'type': 'error',
             'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
             'data': null,
-            'children': [ {
+            'children': [{
                 'type': 'error',
                 'message': 'This is but a sub-report Z',
                 'data': null,
                 'children': []
-            } ]
+            }]
         }, {
             'type': 'success',
             'message': 'Row 2 Student Number Identifier OK',
             'data': null,
-            'children': [ {
+            'children': [{
                 'type': 'success',
                 'message': 'This is but a sub-report A',
                 'data': null,
@@ -77,22 +77,22 @@ define( [
                 'message': 'This is but a sub-report B',
                 'data': null,
                 'children': []
-            } ]
+            }]
         }, {
             'type': 'error',
             'message': 'Row 1 Student Number Identifier: Duplicated student \"92001\"',
             'data': null,
-            'children': [ {
+            'children': [{
                 'type': 'error',
                 'message': 'This is but a sub-report Z',
                 'data': null,
                 'children': []
-            } ]
+            }]
         }, {
             'type': 'success',
             'message': 'Row 2 Student Number Identifier OK',
             'data': null,
-            'children': [ {
+            'children': [{
                 'type': 'success',
                 'message': 'This is but a sub-report A',
                 'data': null,
@@ -102,8 +102,8 @@ define( [
                 'message': 'This is but a sub-report B',
                 'data': null,
                 'children': []
-            } ]
-        } ]
+            }]
+        }]
     };
     var _sampleLogCollection = [
         {
@@ -115,7 +115,7 @@ define( [
             createdAt: '1512120107',
             updatedAt: '1512121107',
             createdAtElapsed: 601,
-            updatedAtElapsed:26,
+            updatedAtElapsed: 26,
             hasFile: false,
             category: 'import',
             redirectUrl: 'http://tao.local/taoBackOffice/Redirector/redirectTaskToInstance?taskId=http%3A%2F%2Ftao%2Ftao.rdf%23i15366738451441107',
@@ -135,7 +135,7 @@ define( [
             createdAt: '1512122107',
             updatedAt: '1512123107',
             createdAtElapsed: 41,
-            updatedAtElapsed:626,
+            updatedAtElapsed: 626,
             hasFile: false,
             category: 'publish',
             report: {
@@ -154,240 +154,240 @@ define( [
             createdAt: '1512124107',
             updatedAt: '1512125107',
             createdAtElapsed: 61,
-            updatedAtElapsed:101,
+            updatedAtElapsed: 101,
             hasFile: true,
             category: 'export',
             report: {
                 type: 'error',
                 message: 'running task rdf#i1508337970190342',
                 data: null,
-                children: [ _sampleReport ]
+                children: [_sampleReport]
             }
         }
     ];
 
-    QUnit.module( 'API' );
+    QUnit.module('API');
 
-    QUnit.test( 'module', function( assert ) {
-        assert.expect( 3 );
+    QUnit.test('module', function(assert) {
+        assert.expect(3);
 
-        assert.equal( typeof taskQueueManagerFactory, 'function', 'The taskQueueManagerFactory module exposes a function' );
-        assert.equal( typeof taskQueueManagerFactory(), 'object', 'The taskQueueManagerFactory produces an object' );
-        assert.notStrictEqual( taskQueueManagerFactory(), taskQueueManagerFactory(), 'The taskQueueManagerFactory provides a different object on each call' );
-    } );
+        assert.equal(typeof taskQueueManagerFactory, 'function', 'The taskQueueManagerFactory module exposes a function');
+        assert.equal(typeof taskQueueManagerFactory(), 'object', 'The taskQueueManagerFactory produces an object');
+        assert.notStrictEqual(taskQueueManagerFactory(), taskQueueManagerFactory(), 'The taskQueueManagerFactory provides a different object on each call');
+    });
 
-    QUnit.cases.init( [
-        { title: 'init' },
-        { title: 'destroy' },
-        { title: 'render' },
-        { title: 'show' },
-        { title: 'hide' },
-        { title: 'enable' },
-        { title: 'disable' },
-        { title: 'is' },
-        { title: 'setState' },
-        { title: 'getContainer' },
-        { title: 'getElement' },
-        { title: 'getTemplate' },
-        { title: 'setTemplate' }
-    ] ).test( 'Component API ', function( data, assert ) {
+    QUnit.cases.init([
+        {title: 'init'},
+        {title: 'destroy'},
+        {title: 'render'},
+        {title: 'show'},
+        {title: 'hide'},
+        {title: 'enable'},
+        {title: 'disable'},
+        {title: 'is'},
+        {title: 'setState'},
+        {title: 'getContainer'},
+        {title: 'getElement'},
+        {title: 'getTemplate'},
+        {title: 'setTemplate'}
+    ]).test('Component API ', function(data, assert) {
         var instance = taskQueueManagerFactory();
         assert.equal(typeof instance[data.title], 'function', 'The taskQueueManager exposes the component method "' + data.title);
     });
 
-    QUnit.cases.init( [
-        { title: 'on' },
-        { title: 'off' },
-        { title: 'trigger' },
-        { title: 'before' },
-        { title: 'after' }
-    ] ).test( 'Eventifier API ', function( data, assert ) {
+    QUnit.cases.init([
+        {title: 'on'},
+        {title: 'off'},
+        {title: 'trigger'},
+        {title: 'before'},
+        {title: 'after'}
+    ]).test('Eventifier API ', function(data, assert) {
         var instance = taskQueueManagerFactory();
         assert.equal(typeof instance[data.title], 'function', 'The taskQueueManager exposes the eventifier method "' + data.title);
     });
 
-    QUnit.cases.init( [
-        { title: 'getTaskElements' },
-        { title: 'showDetail' },
-        { title: 'addNewTask' },
-        { title: 'selfUpdateBadge' },
-        { title: 'loadData' },
-        { title: 'pulse' },
-        { title: 'showList' },
-        { title: 'hideList' }
-    ] ).test( 'Instance API ', function( data, assert ) {
+    QUnit.cases.init([
+        {title: 'getTaskElements'},
+        {title: 'showDetail'},
+        {title: 'addNewTask'},
+        {title: 'selfUpdateBadge'},
+        {title: 'loadData'},
+        {title: 'pulse'},
+        {title: 'showList'},
+        {title: 'hideList'}
+    ]).test('Instance API ', function(data, assert) {
         var instance = taskQueueManagerFactory();
         assert.equal(typeof instance[data.title], 'function', 'The taskQueueManager exposes the method "' + data.title);
     });
 
-    QUnit.module( 'Behavior' );
+    QUnit.module('Behavior');
 
-    QUnit.test( 'rendering', function( assert ) {
+    QUnit.test('rendering', function(assert) {
         var ready = assert.async();
 
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        taskQueueManagerFactory( {}, _sampleLogCollection )
-            .on( 'render', function() {
+        taskQueueManagerFactory({}, _sampleLogCollection)
+            .on('render', function() {
 
-                assert.equal( this.getElement().get( 0 ), $container.find( '.task-manager-container' ).get( 0 ), 'component container found' );
+                assert.equal(this.getElement().get(0), $container.find('.task-manager-container').get(0), 'component container found');
 
-                assert.equal( this.getElement().find( '.badge-component' ).length, 1, 'badge component found' );
-                assert.ok( this.getElement().find( '.badge-component .loader' ).is( ':visible' ), 'the loader is on' );
-                assert.ok( this.getElement().find( '.badge-component .badge' ).hasClass( 'badge-warning' ), 'the badge is displaying a warning' );
-                assert.equal( this.getElement().find( '.badge-component .badge' ).text(), '3', 'the badge value is correct' );
+                assert.equal(this.getElement().find('.badge-component').length, 1, 'badge component found');
+                assert.ok(this.getElement().find('.badge-component .loader').is(':visible'), 'the loader is on');
+                assert.ok(this.getElement().find('.badge-component .badge').hasClass('badge-warning'), 'the badge is displaying a warning');
+                assert.equal(this.getElement().find('.badge-component .badge').text(), '3', 'the badge value is correct');
 
-                assert.equal( this.getElement().find( '.task-listing' ).length, 1, 'list component found' );
-                assert.ok( !this.getElement().find( '.task-listing' ).is( ':visible' ), 'list starts hidden' );
-                assert.equal( this.getElement().find( '.task-listing .task-list li' ).length, 3, 'list has 3 elements' );
+                assert.equal(this.getElement().find('.task-listing').length, 1, 'list component found');
+                assert.ok(!this.getElement().find('.task-listing').is(':visible'), 'list starts hidden');
+                assert.equal(this.getElement().find('.task-listing .task-list li').length, 3, 'list has 3 elements');
 
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-    QUnit.test( 'show list & report', function( assert ) {
+    QUnit.test('show list & report', function(assert) {
         var ready = assert.async();
 
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        taskQueueManagerFactory( {}, _sampleLogCollection )
-            .on( 'render', function() {
+        taskQueueManagerFactory({}, _sampleLogCollection)
+            .on('render', function() {
                 this.getElement().click();
-            } )
-            .on( 'listshow', function() {
+            })
+            .on('listshow', function() {
 
-                assert.ok( true, 'list shown' );
+                assert.ok(true, 'list shown');
 
-                this.showDetail( _sampleLogCollection[ 2 ] );
+                this.showDetail(_sampleLogCollection[2]);
 
-                assert.ok( !this.getElement().find( '.task-listing .task-list' ).is( ':visible' ), 'the list is hidden' );
-                assert.ok( this.getElement().find( '.task-listing .view-detail' ).is( ':visible' ), 'the detail is displayed' );
+                assert.ok(!this.getElement().find('.task-listing .task-list').is(':visible'), 'the list is hidden');
+                assert.ok(this.getElement().find('.task-listing .view-detail').is(':visible'), 'the detail is displayed');
 
                 //Hide the list
                 this.getElement().click();
-            } )
-            .on( 'listhide', function() {
+            })
+            .on('listhide', function() {
 
-                assert.ok( true, 'list hidden' );
+                assert.ok(true, 'list hidden');
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-    QUnit.test( 'show / hide list', function( assert ) {
+    QUnit.test('show / hide list', function(assert) {
         var ready = assert.async();
 
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        assert.expect( 5 );
+        assert.expect(5);
 
-        taskQueueManagerFactory( {}, _sampleLogCollection )
-            .on( 'render', function() {
-                assert.ok( !this.getElement().find( '.task-listing .task-list' ).is( ':visible' ), 'the list is hidden by default' );
+        taskQueueManagerFactory({}, _sampleLogCollection)
+            .on('render', function() {
+                assert.ok(!this.getElement().find('.task-listing .task-list').is(':visible'), 'the list is hidden by default');
 
                 this.showList();
-            } )
-            .on( 'listshow', function() {
-                assert.ok( true, 'listshown event has been triggered' );
-                assert.ok( this.getElement().find( '.task-listing .task-list' ).is( ':visible' ), 'the list is visible' );
+            })
+            .on('listshow', function() {
+                assert.ok(true, 'listshown event has been triggered');
+                assert.ok(this.getElement().find('.task-listing .task-list').is(':visible'), 'the list is visible');
 
                 this.hideList();
-            } )
-            .on( 'listhide', function() {
-                assert.ok( true, 'listhidden event has been triggered' );
-                assert.ok( !this.getElement().find( '.task-listing .task-list' ).is( ':visible' ), 'the list has been hidden' );
+            })
+            .on('listhide', function() {
+                assert.ok(true, 'listhidden event has been triggered');
+                assert.ok(!this.getElement().find('.task-listing .task-list').is(':visible'), 'the list has been hidden');
 
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-    QUnit.test( 'removeAllFinished', function( assert ) {
+    QUnit.test('removeAllFinished', function(assert) {
         var ready = assert.async();
 
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        taskQueueManagerFactory( {}, _sampleLogCollection )
-            .on( 'render', function() {
+        taskQueueManagerFactory({}, _sampleLogCollection)
+            .on('render', function() {
 
-                assert.equal( this.getElement().get( 0 ), $container.find( '.task-manager-container' ).get( 0 ), 'component container found' );
+                assert.equal(this.getElement().get(0), $container.find('.task-manager-container').get(0), 'component container found');
 
-                assert.equal( this.getElement().find( '.badge-component' ).length, 1, 'badge component found' );
-                assert.ok( this.getElement().find( '.badge-component .loader' ).is( ':visible' ), 'the loader is on' );
-                assert.ok( this.getElement().find( '.badge-component .badge' ).hasClass( 'badge-warning' ), 'the badge is displaying a warning' );
-                assert.equal( this.getElement().find( '.badge-component .badge' ).text(), '3', 'the badge value is correct' );
+                assert.equal(this.getElement().find('.badge-component').length, 1, 'badge component found');
+                assert.ok(this.getElement().find('.badge-component .loader').is(':visible'), 'the loader is on');
+                assert.ok(this.getElement().find('.badge-component .badge').hasClass('badge-warning'), 'the badge is displaying a warning');
+                assert.equal(this.getElement().find('.badge-component .badge').text(), '3', 'the badge value is correct');
 
-                assert.equal( this.getElement().find( '.task-listing' ).length, 1, 'list component found' );
-                assert.ok( !this.getElement().find( '.task-listing' ).is( ':visible' ), 'list starts hidden' );
-                assert.equal( this.getElement().find( '.task-listing .task-list li' ).length, 3, 'list has 3 elements' );
+                assert.equal(this.getElement().find('.task-listing').length, 1, 'list component found');
+                assert.ok(!this.getElement().find('.task-listing').is(':visible'), 'list starts hidden');
+                assert.equal(this.getElement().find('.task-listing .task-list li').length, 3, 'list has 3 elements');
 
                 this.removeAllFinished();
 
-                assert.ok( this.getElement().find( '.badge-component .badge' ).hasClass( 'badge-info' ), 'the badge is displaying a info' );
-                assert.equal( this.getElement().find( '.badge-component .badge' ).text(), '1', 'the badge value is correct' );
+                assert.ok(this.getElement().find('.badge-component .badge').hasClass('badge-info'), 'the badge is displaying a info');
+                assert.equal(this.getElement().find('.badge-component .badge').text(), '1', 'the badge value is correct');
 
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-    QUnit.test( 'clearAll', function( assert ) {
+    QUnit.test('clearAll', function(assert) {
         var ready = assert.async();
 
-        var $container = $( '#qunit-fixture' );
+        var $container = $('#qunit-fixture');
 
-        taskQueueManagerFactory( {}, _sampleLogCollection )
-            .on( 'render', function() {
+        taskQueueManagerFactory({}, _sampleLogCollection)
+            .on('render', function() {
 
-                assert.equal( this.getElement().get( 0 ), $container.find( '.task-manager-container' ).get( 0 ), 'component container found' );
+                assert.equal(this.getElement().get(0), $container.find('.task-manager-container').get(0), 'component container found');
 
-                assert.equal( this.getElement().find( '.badge-component' ).length, 1, 'badge component found' );
-                assert.ok( this.getElement().find( '.badge-component .loader' ).is( ':visible' ), 'the loader is on' );
-                assert.ok( this.getElement().find( '.badge-component .badge' ).hasClass( 'badge-warning' ), 'the badge is displaying a warning' );
-                assert.equal( this.getElement().find( '.badge-component .badge' ).text(), '3', 'the badge value is correct' );
+                assert.equal(this.getElement().find('.badge-component').length, 1, 'badge component found');
+                assert.ok(this.getElement().find('.badge-component .loader').is(':visible'), 'the loader is on');
+                assert.ok(this.getElement().find('.badge-component .badge').hasClass('badge-warning'), 'the badge is displaying a warning');
+                assert.equal(this.getElement().find('.badge-component .badge').text(), '3', 'the badge value is correct');
 
-                assert.equal( this.getElement().find( '.task-listing' ).length, 1, 'list component found' );
-                assert.ok( !this.getElement().find( '.task-listing' ).is( ':visible' ), 'list starts hidden' );
-                assert.equal( this.getElement().find( '.task-listing .task-list li' ).length, 3, 'list has 3 elements' );
+                assert.equal(this.getElement().find('.task-listing').length, 1, 'list component found');
+                assert.ok(!this.getElement().find('.task-listing').is(':visible'), 'list starts hidden');
+                assert.equal(this.getElement().find('.task-listing .task-list li').length, 3, 'list has 3 elements');
 
-                assert.equal( this.getElement().find( '.clear-all' ).length, 1, 'clear all button found' );
+                assert.equal(this.getElement().find('.clear-all').length, 1, 'clear all button found');
 
                 //Trigger cleanup
-                this.getElement().find( '.clear-all' ).click();
+                this.getElement().find('.clear-all').click();
 
-                assert.ok( this.getElement().find( '.badge-component .badge' ).hasClass( 'badge-info' ), 'the badge is displaying a info' );
-                assert.equal( this.getElement().find( '.badge-component .badge' ).text(), '1', 'the badge value is correct' );
+                assert.ok(this.getElement().find('.badge-component .badge').hasClass('badge-info'), 'the badge is displaying a info');
+                assert.equal(this.getElement().find('.badge-component .badge').text(), '1', 'the badge value is correct');
 
                 ready();
-            } )
-            .render( $container );
-    } );
+            })
+            .render($container);
+    });
 
-    QUnit.module( 'Visual' );
+    QUnit.module('Visual');
 
-    QUnit.test( 'playground', function( assert ) {
+    QUnit.test('playground', function(assert) {
         var ready = assert.async();
 
         var taskManager;
-        var $container = $( '#visual' );
-        var $controls = $container.find( '#controls' );
-        var $list = $controls.find( 'ul' );
+        var $container = $('#visual');
+        var $controls = $container.find('#controls');
+        var $list = $controls.find('ul');
 
-        var getRandomValue = function getRandomValue( arr ) {
-            return arr[ Math.floor( Math.random() * arr.length ) ];
+        var getRandomValue = function getRandomValue(arr) {
+            return arr[Math.floor(Math.random() * arr.length)];
         };
 
-        var updateTestTask = function updateTestTask( id, status ) {
+        var updateTestTask = function updateTestTask(id, status) {
             var elements = taskManager.getTaskElements();
-            if ( id && elements[ id ] ) {
-                elements[ id ].update( {
+            if (id && elements[id]) {
+                elements[id].update({
                     status: status,
-                    updatedAt: Math.floor( Date.now() / 1000 ),
+                    updatedAt: Math.floor(Date.now() / 1000),
                     updatedAtElapsed: 0
-                } );
+                });
             }
-            taskManager.trigger( 'listchange' );
+            taskManager.trigger('listchange');
         };
 
         var updateTaskList = function updateTaskList() {
@@ -396,59 +396,59 @@ define( [
                 if(task.getStatus() === 'in_progress'){
                     $list.append('<li data-id="'+task.getId()+'"><span class="name">'+task.getData().taskLabel+'</span><a class="task-complete">complete it</a><a class="task-fail">fail it</a> </li>');
                 }
-            } );
+            });
         };
 
         var createTask = function createTask() {
-            var timestamp = Math.floor( Date.now() / 1000 );
-            var type = getRandomValue( [ 'import', 'export', 'publish', 'transfer', 'create', 'update', 'delete' ] );
+            var timestamp = Math.floor(Date.now() / 1000);
+            var type = getRandomValue(['import', 'export', 'publish', 'transfer', 'create', 'update', 'delete']);
 
             return {
-                id: 'rdf#i' + ( Math.floor( Math.random() * 123456789 ) +  123456789 ),
+                id: 'rdf#i' + (Math.floor(Math.random() * 123456789) + 123456789),
                 taskName: 'php/class/for/task/' + type,
-                taskLabel: 'Async ' +  type + ' ' + ( Math.floor( Math.random() * 99 ) +  1 ),
+                taskLabel: 'Async ' + type + ' ' + (Math.floor(Math.random() * 99) + 1),
                 status: 'in_progress',
                 owner: 'userId',
                 createdAt: timestamp,
                 updatedAt: timestamp,
                 updatedAtElapsed: 0,
                 createdAtElapsed: 0,
-                file: getRandomValue( [ true, false ] ),
+                file: getRandomValue([true, false]),
                 category: type,
                 report: null
             };
         };
 
-        $list.on( 'click', '.task-complete', function() {
-            var id = $( this ).closest( 'li' ).data( 'id' );
-            updateTestTask( id, 'completed' );
+        $list.on('click', '.task-complete', function() {
+            var id = $(this).closest('li').data('id');
+            updateTestTask(id, 'completed');
             updateTaskList();
 
-        } ).on( 'click', '.task-fail', function() {
-            var id = $( this ).closest( 'li' ).data( 'id' );
-            updateTestTask( id, 'failed' );
+        }).on('click', '.task-fail', function() {
+            var id = $(this).closest('li').data('id');
+            updateTestTask(id, 'failed');
             updateTaskList();
-        } );
+        });
 
-        taskManager = taskQueueManagerFactory( {}, _sampleLogCollection )
-            .on( 'report', function() {
+        taskManager = taskQueueManagerFactory({}, _sampleLogCollection)
+            .on('report', function() {
 
                 //Fetch report
-                this.showDetail( _sampleLogCollection[ 2 ] );
-            } )
-            .on( 'render', function() {
+                this.showDetail(_sampleLogCollection[2]);
+            })
+            .on('render', function() {
                 var self = this;
-                assert.ok( true );
+                assert.ok(true);
 
-                $controls.find( '.add-task' ).click( function() {
-                    self.addNewTask( createTask(), true );
+                $controls.find('.add-task').click(function() {
+                    self.addNewTask(createTask(), true);
                     updateTaskList();
-                } );
+                });
 
                 ready();
-            } )
-            .render( $container );
+            })
+            .render($container);
 
         updateTaskList();
-    } );
-} );
+    });
+});


### PR DESCRIPTION
**task** https://oat-sa.atlassian.net/browse/TAO-7629

 **description**  convert all unit tests for frontend part to latest Qunit 2 version. More details - in task.
 
**related PRs**`
https://github.com/oat-sa/extension-tao-xmledit/pull/18
https://github.com/oat-sa/extension-tao-test/pull/273
https://github.com/oat-sa/extension-tao-test-runner-plugins/pull/96
https://github.com/oat-sa/extension-tao-testcenter/pull/118
https://github.com/oat-sa/extension-tao-testqti-previewer/pull/14
https://github.com/oat-sa/extension-tao-testqti/pull/1446
https://github.com/oat-sa/extension-tao-qtiprint/pull/56
https://github.com/oat-sa/extension-tao-itemqti/pull/1248
https://github.com/oat-sa/extension-tao-proctoring/pull/673
https://github.com/oat-sa/extension-tao-outcomeui/pull/254
https://github.com/oat-sa/extension-tao-item/pull/355
https://github.com/oat-sa/extension-tao-clientdiag/pull/223
https://github.com/oat-sa/extension-tao-booklet/pull/82
https://github.com/oat-sa/extension-tao-blueprints/pull/20
https://github.com/oat-sa/extension-tao-itemqti-pci/pull/147
https://github.com/oat-sa/extension-pcisample/pull/44