### PR TITLE
Feature/add time to report

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Task Queue',
     'description' => 'Extended Task Queue functionalities with custom GUI',
     'license' => 'GPL-2.0',
-    'version' => '2.1.0',
+    'version' => '2.1.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=5.8.0',

--- a/scripts/tools/RunWorker.php
+++ b/scripts/tools/RunWorker.php
@@ -20,6 +20,7 @@
 
 namespace oat\taoTaskQueue\scripts\tools;
 
+use DateTime;
 use oat\oatbox\action\Action;
 use oat\tao\model\taskQueue\QueueDispatcherInterface;
 use oat\tao\model\taskQueue\TaskLogInterface;
@@ -94,8 +95,7 @@ class RunWorker implements Action, ServiceLocatorAwareInterface
         } catch (\Exception $e) {
             return \common_report_Report::createFailure($e->getMessage());
         }
-
-        return \common_report_Report::createSuccess('Worker finished');
+        return \common_report_Report::createSuccess('Worker finished at ' . (new DateTime('now'))->format(DateTime::ATOM));
     }
 }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -250,6 +250,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.1.0');
         }
 
-        $this->skip('1.1.0', '2.1.0');
+        $this->skip('1.1.0', '2.1.1');
     }
 }


### PR DESCRIPTION
On the worker log we just have a list of `Worker finished` messages which are not very useful.
Be able to get time when it was finished may be convenient in investigation of support issues.