### PR TITLE
TTD-18 Tests extends from `generis\test\TestCase`. All mock objects e…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Task Queue',
     'description' => 'Extended Task Queue functionalities with custom GUI',
     'license' => 'GPL-2.0',
-    'version' => '4.0.0',
+    'version' => '4.1.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=5.8.0',

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return array(
     'version' => '4.1.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'generis' => '>=5.8.0',
+        'generis' => '>=12.5.0',
         'tao' => '>=38.9.5'
     ),
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#taoTaskQueueManager',

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Task Queue',
     'description' => 'Extended Task Queue functionalities with custom GUI',
     'license' => 'GPL-2.0',
-    'version' => '4.1.0',
+    'version' => '5.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -250,6 +250,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.1.0');
         }
 
-        $this->skip('1.1.0', '4.1.0');
+        $this->skip('1.1.0', '5.0.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -250,6 +250,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.1.0');
         }
 
-        $this->skip('1.1.0', '4.0.0');
+        $this->skip('1.1.0', '4.1.0');
     }
 }

--- a/test/model/Entity/TaskLogEntityTest.php
+++ b/test/model/Entity/TaskLogEntityTest.php
@@ -24,11 +24,12 @@ use common_report_Report as Report;
 use oat\taoTaskQueue\model\Entity\TaskLogEntity;
 use oat\taoTaskQueue\model\TaskLogInterface;
 use oat\taoTaskQueue\model\ValueObjects\TaskLogCategorizedStatus;
+use oat\generis\test\TestCase;
 
 /**
  * @deprecated
  */
-class TaskLogEntityTest extends \PHPUnit_Framework_TestCase
+class TaskLogEntityTest extends TestCase
 {
     public function testEntityCreated()
     {

--- a/test/model/Entity/TasksLogsStatsTest.php
+++ b/test/model/Entity/TasksLogsStatsTest.php
@@ -22,11 +22,12 @@ namespace oat\taoTaskQueue\test\model\Entity;
 
 
 use oat\taoTaskQueue\model\Entity\TasksLogsStats;
+use oat\generis\test\TestCase;
 
 /**
  * @deprecated
  */
-class TasksLogsStatsTest extends \PHPUnit_Framework_TestCase
+class TasksLogsStatsTest extends TestCase
 {
     public function testCreateStats()
     {

--- a/test/model/Task/AbstractTaskTest.php
+++ b/test/model/Task/AbstractTaskTest.php
@@ -22,11 +22,12 @@ namespace oat\taoTaskQueue\test\model\Task;
 
 use oat\taoTaskQueue\model\Task\AbstractTask;
 use oat\taoTaskQueue\model\Task\TaskInterface;
+use oat\generis\test\TestCase;
 
 /**
  * @deprecated
  */
-class AbstractTaskTest extends \PHPUnit_Framework_TestCase
+class AbstractTaskTest extends TestCase
 {
     /**
      * @var AbstractTask

--- a/test/model/TaskLog/TaskLogFilterTest.php
+++ b/test/model/TaskLog/TaskLogFilterTest.php
@@ -23,11 +23,12 @@ namespace oat\taoTaskQueue\test\model\TaskLog;
 use oat\taoTaskQueue\model\TaskLog\TaskLogFilter;
 use oat\taoTaskQueue\model\TaskLogBroker\TaskLogBrokerInterface;
 use oat\taoTaskQueue\model\TaskLogInterface;
+use oat\generis\test\TestCase;
 
 /**
  * @deprecated
  */
-class TaskLogFilterTest extends \PHPUnit_Framework_TestCase
+class TaskLogFilterTest extends TestCase
 {
     /** @var  TaskLogFilter */
     private $filter;

--- a/test/model/TaskLogActionTraitTest.php
+++ b/test/model/TaskLogActionTraitTest.php
@@ -25,8 +25,9 @@ use oat\taoTaskQueue\model\Entity\TaskLogEntity;
 use oat\taoTaskQueue\model\TaskLog;
 use oat\taoTaskQueue\model\TaskLogActionTrait;
 use oat\taoTaskQueue\model\ValueObjects\TaskLogCategorizedStatus;
+use oat\generis\test\TestCase;
 
-class TaskLogActionTraitTest extends \PHPUnit_Framework_TestCase
+class TaskLogActionTraitTest extends TestCase
 {
     public function testGetTaskLogEntityWhenOnlyTaskIdIsProvidedThenGetTheDefaultUser()
     {

--- a/test/model/TaskLogBroker/RdsTaskLogBrokerTest.php
+++ b/test/model/TaskLogBroker/RdsTaskLogBrokerTest.php
@@ -22,11 +22,12 @@ namespace oat\taoTaskQueue\test\model\TaskLogBroker;
 
 use oat\oatbox\service\ServiceManager;
 use oat\taoTaskQueue\model\TaskLogBroker\RdsTaskLogBroker;
+use oat\generis\test\TestCase;
 
 /**
  * @deprecated
  */
-class RdsTaskLogBrokerTest extends \PHPUnit_Framework_TestCase
+class RdsTaskLogBrokerTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/test/model/TaskLogBroker/TaskLogCollectionTest.php
+++ b/test/model/TaskLogBroker/TaskLogCollectionTest.php
@@ -22,11 +22,12 @@ namespace oat\taoTaskQueue\model\TaskLogBroker;
 
 use oat\taoTaskQueue\model\TaskLog\TaskLogCollection;
 use oat\taoTaskQueue\model\TaskLogInterface;
+use oat\generis\test\TestCase;
 
 /**
  * @deprecated
  */
-class TaskLogCollectionTest extends \PHPUnit_Framework_TestCase
+class TaskLogCollectionTest extends TestCase
 {
     /**
      * @throws \Exception

--- a/test/model/ValueObjects/TaskLogCategorizedStatusTest.php
+++ b/test/model/ValueObjects/TaskLogCategorizedStatusTest.php
@@ -22,11 +22,12 @@ namespace oat\taoTaskQueue\test\model\ValueObjects;
 
 
 use oat\taoTaskQueue\model\ValueObjects\TaskLogCategorizedStatus;
+use oat\generis\test\TestCase;
 
 /**
  * @deprecated
  */
-class TaskLogCategorizedStatusTest extends \PHPUnit_Framework_TestCase
+class TaskLogCategorizedStatusTest extends TestCase
 {
     /**
      * @throws \Exception

--- a/test/model/Worker/WorkerProcessManagerTest.php
+++ b/test/model/Worker/WorkerProcessManagerTest.php
@@ -23,8 +23,9 @@ use oat\taoTaskQueue\model\Worker\WorkerProcessManager;
 use React\ChildProcess\Process;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableStreamInterface;
+use oat\generis\test\TestCase;
 
-class WorkerProcessManagerTest extends \PHPUnit_Framework_TestCase
+class WorkerProcessManagerTest extends TestCase
 {
     public function testAddProcess()
     {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.