### PR TITLE
Updated dependencies on composer.json and doc on Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ try {
 ```
 
 __Note__: 
-> Before run the commands, please make sure that you're on the tao root folder:
+> Before run the commands, please make sure that you're on the tao root folder.
 
 ### Initializing the queues and the task log container
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ try {
 }
 ```
 
+### Running Commands
+
+Please make sure that you're on the tao root folder before run the commands:
+
+```bash
+ $ cd /path/to/your/tao/instance
+```
+
+
 ### Initializing the queues and the task log container
 
 You can run this script if you want to be sure that the required queues and the task log container are created.

--- a/README.md
+++ b/README.md
@@ -83,14 +83,8 @@ try {
 }
 ```
 
-### Running Commands
-
-Please make sure that you're on the tao root folder before run the commands:
-
-```bash
- $ cd /path/to/your/tao/instance
-```
-
+__Note__: 
+> Before run the commands, please make sure that you're on the tao root folder:
 
 ### Initializing the queues and the task log container
 

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "minimum-stability": "dev",
     "require": {
         "php" : ">=5.5",
+        "ext-pcntl":  "*",
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "react/child-process": "^0.5.2",
         "evenement/evenement": "^2.0"

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Task Queue',
     'description' => 'Extended Task Queue functionalities with custom GUI',
     'license' => 'GPL-2.0',
-    'version' => '5.0.1',
+    'version' => '5.0.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis' => '>=12.5.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -251,6 +251,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('1.1.0');
         }
 
-        $this->skip('1.1.0', '5.0.1');
+        $this->skip('1.1.0', '5.0.2');
     }
 }


### PR DESCRIPTION
The pcntl extension is required when executing worker commands.
Updated readme.md just to explain that the command should be executed in the TAO folder, not within this project.