### PR TITLE
taskqueue logs improvement

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Task Queue',
     'description' => 'Extended Task Queue functionalities with custom GUI',
     'license' => 'GPL-2.0',
-    'version' => '5.5.0',
+    'version' => '5.5.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis' => '>=12.20.2',

--- a/model/Entity/TaskLogEntity.php
+++ b/model/Entity/TaskLogEntity.php
@@ -21,6 +21,7 @@
 
 namespace oat\taoTaskQueue\model\Entity;
 
+use common_exception_Error;
 use common_report_Report as Report;
 use DateTime;
 use Exception;
@@ -109,10 +110,11 @@ class TaskLogEntity extends BaseTaskLogEntity implements TaskLogEntityInterface
 
     /**
      * @param array $row
+     * @param string $dateFormat
      * @return TaskLogEntity
-     * @throws Exception
+     * @throws common_exception_Error
      */
-    public static function createFromArray(array $row)
+    public static function createFromArray(array $row, string $dateFormat = 'Y-m-d H:i:s')
     {
         return new self(
             $row[TaskLogBrokerInterface::COLUMN_ID],
@@ -122,8 +124,8 @@ class TaskLogEntity extends BaseTaskLogEntity implements TaskLogEntityInterface
             isset($row[TaskLogBrokerInterface::COLUMN_PARAMETERS]) ? json_decode($row[TaskLogBrokerInterface::COLUMN_PARAMETERS], true) : [],
             isset($row[TaskLogBrokerInterface::COLUMN_LABEL]) ? $row[TaskLogBrokerInterface::COLUMN_LABEL] : '',
             isset($row[TaskLogBrokerInterface::COLUMN_OWNER]) ? $row[TaskLogBrokerInterface::COLUMN_OWNER] : '',
-            isset($row[TaskLogBrokerInterface::COLUMN_CREATED_AT]) ? DateTime::createFromFormat('Y-m-d H:i:s', $row[TaskLogBrokerInterface::COLUMN_CREATED_AT], new \DateTimeZone('UTC')) : null,
-            isset($row[TaskLogBrokerInterface::COLUMN_UPDATED_AT]) ? DateTime::createFromFormat('Y-m-d H:i:s', $row[TaskLogBrokerInterface::COLUMN_UPDATED_AT], new \DateTimeZone('UTC')) : null,
+            isset($row[TaskLogBrokerInterface::COLUMN_CREATED_AT]) ? DateTime::createFromFormat($dateFormat, $row[TaskLogBrokerInterface::COLUMN_CREATED_AT], new \DateTimeZone('UTC')) : null,
+            isset($row[TaskLogBrokerInterface::COLUMN_UPDATED_AT]) ? DateTime::createFromFormat($dateFormat, $row[TaskLogBrokerInterface::COLUMN_UPDATED_AT], new \DateTimeZone('UTC')) : null,
             Report::jsonUnserialize($row[TaskLogBrokerInterface::COLUMN_REPORT]),
             isset($row[TaskLogBrokerInterface::COLUMN_MASTER_STATUS]) ? $row[TaskLogBrokerInterface::COLUMN_MASTER_STATUS] : false
         );

--- a/model/LongRunningWorker.php
+++ b/model/LongRunningWorker.php
@@ -92,7 +92,7 @@ final class LongRunningWorker extends AbstractWorker
                 if (!$task) {
                     ++$this->iterationsWithOutTask;
                     $waitInterval = $this->getWaitInterval();
-                    $this->logInfo('No tasks found. Sleeping for ' . $waitInterval . ' sec', $this->getLogContext());
+                    $this->logDebug('No tasks found. Sleeping for ' . $waitInterval . ' sec', $this->getLogContext());
                     usleep($waitInterval * 1000000);
 
                     continue;


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-10529

- message `no tasks in the queue` set as debut (instead of info)
- fixed unit tests