### PR TITLE
[Fix] Change the Broker to use the allowable number of tasks based on free space in the Worker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "evenement/evenement": "^2.0",
         "ext-pdo": "*",
         "oat-sa/generis" : ">=15.22",
-        "oat-sa/tao-core" : ">=50.24.6"
+        "oat-sa/tao-core" : "dev-fix/adf-1571/process-tasks-based-on-worker-free-space as 53.6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "evenement/evenement": "^2.0",
         "ext-pdo": "*",
         "oat-sa/generis" : ">=15.22",
-        "oat-sa/tao-core" : "dev-fix/adf-1571/process-tasks-based-on-worker-free-space as 53.6.0"
+        "oat-sa/tao-core" : ">=53.6.0"
     },
     "autoload": {
         "psr-4": {

--- a/model/LongRunningWorker.php
+++ b/model/LongRunningWorker.php
@@ -81,6 +81,8 @@ final class LongRunningWorker extends AbstractWorker
                 continue;
             }
 
+            ++$this->iterations;
+
             try {
                 $this->logDebug('Fetching tasks from queue ', $this->getLogContext());
 
@@ -108,7 +110,6 @@ final class LongRunningWorker extends AbstractWorker
                     continue;
                 }
 
-                ++$this->iterations;
                 $this->processTask($task);
 
                 unset($task);
@@ -226,7 +227,7 @@ final class LongRunningWorker extends AbstractWorker
 
     private function hasEnoughSpace(): bool
     {
-        if (!$this->queuer instanceof QueueInterface || $this->queuer->hasPreFetchedMessages()) {
+        if ($this->queuer->hasPreFetchedMessages()) {
             return true;
         }
 

--- a/model/LongRunningWorker.php
+++ b/model/LongRunningWorker.php
@@ -227,7 +227,7 @@ final class LongRunningWorker extends AbstractWorker
 
     private function hasEnoughSpace(): bool
     {
-        if ($this->queuer->hasPreFetchedMessages()) {
+        if ($this->iterationsWithOutTask || $this->queuer->hasPreFetchedMessages()) {
             return true;
         }
 


### PR DESCRIPTION
# [ADF-1571](https://oat-sa.atlassian.net/browse/ADF-1571)

## Changelog
* Now iterations counter will increment only if there's a task to process
* If the `--limit` option is given to the worker, the free space will be taken into account when selecting tasks. If there is no free space, the worker will be terminated

## Require PRs
* https://github.com/oat-sa/tao-core/pull/3875

[ADF-1571]: https://oat-sa.atlassian.net/browse/ADF-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ